### PR TITLE
feat: Metapod test shield + docs (README, testing, SPEC pointers)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '20.x'
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
       - name: Lint code
         run: npm run lint
       - name: Run tests
@@ -30,13 +30,43 @@ jobs:
           name: production-build
           path: build/
 
-  deploy:
+  e2e:
+    runs-on: ubuntu-latest
     needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: production-build
+          path: build/
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: npm run test:e2e
+        env:
+          CI: true
+
+  deploy:
+    needs: [build, e2e]
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     environment: production
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: production-build
+          path: build/
       - name: Deploy to Production Server
         env:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
@@ -51,4 +81,3 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.LINEAR_API_KEY }}" \
             -d '{"event": "deploy", "branch": "${{ github.ref }}"}' \
             https://api.linear.app/webhooks/deployment
-

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ coverage/
 .next/
 out/
 
+
+# Playwright / E2E
+playwright-report/
+test-results/
+.playwright/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
-# glitchhub-tarot
-Dark mode glitch art tarot card generator with dev-master/dex/zenOS
+# glitchhub-tarot (Glitchworks — Aether Deck)
+
+Dark-mode **cyber-mystic** card UI: **Dex** (library), **Arena** (clash), **Oracle** (spread), **Forge** (entity builder). React 18 + Vite + Tailwind + lucide-react.
+
+> **Naming:** GitHub repo may appear as **glitchhub-tarot** or **glitchworks-tarot** — same app; check `git remote -v`.
+
+## Quick start (launch)
+
+**Requirements:** Node **20.x**, npm.
+
+```bash
+npm ci --legacy-peer-deps   # install (peer deps: see note below)
+npm run dev                 # http://localhost:5173 (Vite default)
+```
+
+**Production-like local check:**
+
+```bash
+npm run build && npm run preview   # http://localhost:4173
+```
+
+**Peer dependencies:** this repo pins ESLint 10 while some plugins expect ESLint 9 — CI and local installs use `npm ci --legacy-peer-deps`. If `npm install` fails, use the same flag.
+
+## Documentation map
+
+| Doc | Purpose |
+|-----|---------|
+| [`docs/SPEC.md`](docs/SPEC.md) | Where the **full v2.1 product spec** lives (dev-master path + pointers) |
+| [`docs/TESTING.md`](docs/TESTING.md) | **Testing methodology** — Vitest, Playwright, CI, commands |
+| [`docs/TESTIDS.md`](docs/TESTIDS.md) | `data-testid` convention for RTL + E2E |
+| [`docs/AETHER_RAM.ipynb`](docs/AETHER_RAM.ipynb) | Agent / session RAM + optional test run log cells |
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `npm run dev` | Dev server |
+| `npm run build` | Production bundle → `build/` |
+| `npm run preview` | Serve `build/` |
+| `npm run lint` | ESLint |
+| `npm run test` | Vitest (coverage in CI) |
+| `npm run test:watch` | Vitest watch |
+| `npm run test:e2e` | Playwright E2E |
+| `npm run test:e2e:ui` | Playwright UI |
+
+## CI
+
+GitHub Actions: **lint** → **Vitest + coverage** → **build** → **Playwright E2E** (artifact-based). **Deploy** runs only on **push** to `main` / `master` (see `.github/workflows/ci-cd.yml`).
+
+## zenOS / dev-master
+
+When embedded in **dev-master**, this repo lives at `dex/09-repos/glitchhub-tarot`. Cross-repo scratchpad: root `AGENT_RAM.ipynb`; app-specific notes: `docs/AETHER_RAM.ipynb`.
+
+---
+
+*Deck spec v2.1 — see `docs/SPEC.md` for the canonical document location.*

--- a/docs/AETHER_RAM.ipynb
+++ b/docs/AETHER_RAM.ipynb
@@ -1,0 +1,33 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Aether / Metapod \u2014 repo-local agent RAM\n",
+        "\n",
+        "- **Canonical remote:** `glitchhub-tarot` / **glitchworks-tarot** naming \u2014 check `origin` on this clone.\n",
+        "- **Current wave:** test shield (`data-testid`, Vitest+RTL, Playwright, CI `e2e` job).\n",
+        "- **Copy-paste:**\n",
+        "  - `npm run test` \u2014 unit/component\n",
+        "  - `npm run test:e2e` \u2014 Playwright (local: builds+preview; CI: build artifact + preview)\n",
+        "  - `npm run build && npm run preview` \u2014 manual smoke\n",
+        "- **Selectors:** [`docs/TESTIDS.md`](TESTIDS.md)\n",
+        "\n",
+        "Keep this notebook **small**; long lore lives in `dex/03-docs/` on dev-master.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/docs/AETHER_RAM.ipynb
+++ b/docs/AETHER_RAM.ipynb
@@ -16,6 +16,139 @@
         "\n",
         "Keep this notebook **small**; long lore lives in `dex/03-docs/` on dev-master.\n"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Test results log (progress)\n",
+        "\n",
+        "**How this works:** Run the Python cells below. When you **Save** the notebook, Jupyter stores **outputs** inside this `.ipynb` file \u2014 so you get a lightweight, commit-friendly history of \u201cwhat passed when.\u201d\n",
+        "\n",
+        "- Prefer committing after a green run (or after a deliberate \u201cred\u201d snapshot you care about).\n",
+        "- **Vitest** is fast; **E2E** needs Playwright browsers installed (`npx playwright install chromium`).\n",
+        "- If the kernel\u2019s cwd is wrong, cells resolve the repo root automatically (`package.json` next to `src/`).\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Vitest (unit / RTL)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "aether-tests-vitest"
+        ]
+      },
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Run Vitest; output is captured below when you execute + save the notebook.\n",
+        "import subprocess\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "from datetime import datetime, timezone\n",
+        "\n",
+        "def repo_root() -> Path:\n",
+        "    here = Path.cwd().resolve()\n",
+        "    if (here / \"package.json\").exists():\n",
+        "        return here\n",
+        "    if (here.parent / \"package.json\").exists():\n",
+        "        return here.parent\n",
+        "    raise FileNotFoundError(\"Start Jupyter from repo root or from docs/ \u2014 could not find package.json\")\n",
+        "\n",
+        "ROOT = repo_root()\n",
+        "stamp = datetime.now(timezone.utc).strftime(\"%Y-%m-%d %H:%M:%S UTC\")\n",
+        "print(f\"=== Vitest @ {stamp} ===\")\n",
+        "print(f\"repo: {ROOT}\\n\")\n",
+        "\n",
+        "proc = subprocess.run(\n",
+        "    [\"npm\", \"run\", \"test\", \"--\", \"--reporter=verbose\"],\n",
+        "    cwd=ROOT,\n",
+        "    capture_output=True,\n",
+        "    text=True,\n",
+        ")\n",
+        "sys.stdout.write(proc.stdout or \"\")\n",
+        "if proc.stderr:\n",
+        "    sys.stdout.write(\"\\n--- stderr ---\\n\")\n",
+        "    sys.stdout.write(proc.stderr)\n",
+        "print(f\"\\n[exit code {proc.returncode}]\")\n",
+        "if proc.returncode != 0:\n",
+        "    raise RuntimeError(f\"Vitest failed with exit code {proc.returncode}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Playwright E2E (slower)\n",
+        "\n",
+        "Runs `npm run test:e2e` (local config builds + preview unless `CI=true` is set). Set **`CI=1`** in the environment *before* running this cell to match CI (run `npm run build` first in a terminal, then `CI=1 npm run test:e2e`).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": [
+          "aether-tests-e2e"
+        ]
+      },
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import subprocess\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "from datetime import datetime, timezone\n",
+        "\n",
+        "def repo_root() -> Path:\n",
+        "    here = Path.cwd().resolve()\n",
+        "    if (here / \"package.json\").exists():\n",
+        "        return here\n",
+        "    if (here.parent / \"package.json\").exists():\n",
+        "        return here.parent\n",
+        "    raise FileNotFoundError(\"Could not find package.json\")\n",
+        "\n",
+        "ROOT = repo_root()\n",
+        "stamp = datetime.now(timezone.utc).strftime(\"%Y-%m-%d %H:%M:%S UTC\")\n",
+        "print(f\"=== Playwright E2E @ {stamp} ===\")\n",
+        "print(f\"repo: {ROOT}\")\n",
+        "print(f\"CI env: {os.environ.get('CI', '')!r}\\n\")\n",
+        "\n",
+        "env = os.environ.copy()\n",
+        "proc = subprocess.run(\n",
+        "    [\"npm\", \"run\", \"test:e2e\"],\n",
+        "    cwd=ROOT,\n",
+        "    capture_output=True,\n",
+        "    text=True,\n",
+        "    env=env,\n",
+        ")\n",
+        "sys.stdout.write(proc.stdout or \"\")\n",
+        "if proc.stderr:\n",
+        "    sys.stdout.write(\"\\n--- stderr ---\\n\")\n",
+        "    sys.stdout.write(proc.stderr)\n",
+        "print(f\"\\n[exit code {proc.returncode}]\")\n",
+        "if proc.returncode != 0:\n",
+        "    raise RuntimeError(f\"Playwright failed with exit code {proc.returncode}\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Manual paste \u2014 CI / PR / ad-hoc\n",
+        "\n",
+        "Paste GitHub Actions snippets, PR links, or notes here (static text; no execution):\n",
+        "\n",
+        "```text\n",
+        "(paste)\n",
+        "```\n"
+      ]
     }
   ],
   "metadata": {
@@ -25,7 +158,8 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "name": "python",
+      "pygments_lexer": "ipython3"
     }
   },
   "nbformat": 4,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# `docs/` — Aether Deck documentation
+
+| File | Description |
+|------|-------------|
+| [SPEC.md](SPEC.md) | Pointer to the **full v2.1 specification** (lives in dev-master `dex/08-projects/`) |
+| [TESTING.md](TESTING.md) | how we test (Vitest, Playwright, CI) |
+| [TESTIDS.md](TESTIDS.md) | `data-testid` naming and inventory |
+| [AETHER_RAM.ipynb](AETHER_RAM.ipynb) | Agent RAM + optional test output log |
+
+Start from the repo root [README.md](../README.md) for install and launch.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,0 +1,14 @@
+# Specification pointer (Aether Deck)
+
+The **authoritative product/spec document** for Glitchworks / Aether Deck lives in the **dev-master** workspace (not all clones include it):
+
+| Context | Path |
+|--------|------|
+| **dev-master monorepo** | [`dex/08-projects/Glitchworks Tarot-Aether Deck Spec.md`](../../../08-projects/Glitchworks%20Tarot-Aether%20Deck%20Spec.md) (relative from this file: `dex/09-repos/glitchhub-tarot/docs/` → go up to `dex/` then `08-projects/`) |
+| **Standalone clone** of this repo only | Open the same file on GitHub from **dev-master**, or copy the spec into your wiki — the app repo does not vendor the full spec by default. |
+
+**Spec version** referenced in code comments: **v2.1 (Glitchworks Edition)** — see `src/App.jsx` header.
+
+**What the spec covers (summary):** philosophy, stack (React 18, Vite, Tailwind, lucide-react), `Card` entity schema, the four views (Dex, Arena, Oracle, Forge), aesthetics (glitch / CRT / noise).
+
+Keep implementation details (test IDs, CI jobs) in [`TESTIDS.md`](TESTIDS.md) and [`TESTING.md`](TESTING.md).

--- a/docs/TESTIDS.md
+++ b/docs/TESTIDS.md
@@ -1,0 +1,42 @@
+# `data-testid` convention (Aether / Metapod)
+
+Stable hooks for Vitest RTL and Playwright E2E. **Pattern:**
+
+```text
+aether-<area>-<element>
+```
+
+- **`area`**: shell region or feature (`root`, `nav`, `main`, `view-dex`, `modal-settings`, etc.).
+- **`element`**: concrete control or container (`settings-open`, `oracle-draw`, `arena-clash`).
+
+Only add IDs where tests need them (nav, modals, primary actions, key views). Do not spray IDs on every wrapper.
+
+## Current IDs
+
+| `data-testid` | Purpose |
+|---------------|---------|
+| `aether-root` | App shell |
+| `aether-main` | Main content |
+| `aether-nav` | Bottom/top nav bar |
+| `aether-nav-dex` | Dex tab |
+| `aether-nav-arena` | Arena tab |
+| `aether-nav-oracle` | Oracle tab |
+| `aether-nav-forge` | Forge tab |
+| `aether-settings-open` | Open settings (mobile) |
+| `aether-settings-open-desktop` | Open settings (desktop) |
+| `aether-settings-close` | Close settings modal |
+| `aether-modal-settings` | Settings overlay |
+| `aether-modal-settings-panel` | Settings panel |
+| `aether-view-dex` | Dex grid view |
+| `aether-view-arena` | Arena view |
+| `aether-arena-log` | Arena status log |
+| `aether-arena-clash` | Initiate clash |
+| `aether-arena-flush` | Flush arena |
+| `aether-view-oracle` | Oracle view |
+| `aether-oracle-draw` | Draw / recalculate spread |
+| `aether-view-forge` | Forge view |
+| `aether-forge-compile` | Compile entity |
+| `aether-modal-card` | Card detail overlay (dex) |
+| `aether-modal-card-close` | Close card modal |
+
+When splitting `App.jsx`, **keep these IDs stable** on the moved nodes.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,39 @@
+# Testing methodology (Metapod test shield)
+
+## Layers
+
+| Layer | Tool | What it guards |
+|-------|------|----------------|
+| **Unit / component** | Vitest + Testing Library + `jest-dom` | Default render, nav switching, modals, oracle draw — fast feedback in CI |
+| **E2E** | Playwright (Chromium) | Real browser: navigation, settings, oracle, card modal, arena disabled state, double-click spam, no console errors on load |
+| **Selectors** | `data-testid` | Stable hooks; convention: `aether-<area>-<element>` — see [`TESTIDS.md`](TESTIDS.md) |
+
+## Commands
+
+```bash
+npm run lint          # ESLint (src/)
+npm run test          # Vitest once, with coverage in CI
+npm run test:watch    # Vitest watch mode (local)
+npm run build         # Vite → build/
+npm run test:e2e      # Playwright (starts preview; local config may build first — see playwright.config.ts)
+npm run test:e2e:ui   # Playwright UI mode
+```
+
+**Playwright:** first-time setup may need `npx playwright install chromium`.
+
+**CI:** `CI=true` uses preview-only web server after `build` (see `playwright.config.ts`). GitHub Actions runs `build` → artifact → `e2e` job.
+
+## Where tests live
+
+- `src/App.test.jsx` — RTL tests
+- `src/setupTests.js` — `jest-dom` for Vitest
+- `e2e/*.spec.ts` — Playwright specs
+- `vitest.config.js` — `setupFiles`, coverage globs
+
+## Agent / progress log
+
+- Repo-local scratchpad + optional **pasted or executed test output**: [`AETHER_RAM.ipynb`](AETHER_RAM.ipynb)
+
+## PR expectations
+
+Lint + unit tests + build + E2E run on PRs to `main` / `master` (see `.github/workflows/ci-cd.yml`). Deploy is gated to push-to-default-branch only.

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Aether deck — core flows', () => {
+  test('loads shell and dex view', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+    await page.goto('/');
+    await expect(page.getByTestId('aether-root')).toBeVisible();
+    await expect(page.getByTestId('aether-view-dex')).toBeVisible();
+    expect(errors, `console errors: ${errors.join('\n')}`).toHaveLength(0);
+  });
+
+  test('nav switches views', async ({ page }) => {
+    await page.goto('/');
+    await page.getByTestId('aether-nav-arena').click();
+    await expect(page.getByTestId('aether-view-arena')).toBeVisible();
+    await page.getByTestId('aether-nav-oracle').click();
+    await expect(page.getByTestId('aether-view-oracle')).toBeVisible();
+    await page.getByTestId('aether-nav-forge').click();
+    await expect(page.getByTestId('aether-view-forge')).toBeVisible();
+    await page.getByTestId('aether-nav-dex').click();
+    await expect(page.getByTestId('aether-view-dex')).toBeVisible();
+  });
+
+  test('settings modal opens and closes', async ({ page }) => {
+    await page.goto('/');
+    await page.getByTestId('aether-settings-open-desktop').click();
+    await expect(page.getByTestId('aether-modal-settings')).toBeVisible();
+    await page.getByTestId('aether-settings-close').click();
+    await expect(page.getByTestId('aether-modal-settings')).toHaveCount(0);
+  });
+
+  test('oracle draw shows spread labels', async ({ page }) => {
+    await page.goto('/');
+    await page.getByTestId('aether-nav-oracle').click();
+    await page.getByTestId('aether-oracle-draw').click();
+    await expect(page.getByText('T-Minus (Past)')).toBeVisible();
+  });
+
+  test('dex: open card modal and close', async ({ page }) => {
+    await page.goto('/');
+    await page.getByText('The Fool').click();
+    await expect(page.getByTestId('aether-modal-card')).toBeVisible();
+    await page.getByTestId('aether-modal-card-close').click();
+    await expect(page.getByTestId('aether-modal-card')).toHaveCount(0);
+  });
+
+  test('arena clash button disabled without slots', async ({ page }) => {
+    await page.goto('/');
+    await page.getByTestId('aether-nav-arena').click();
+    const clash = page.getByTestId('aether-arena-clash');
+    await expect(clash).toBeDisabled();
+  });
+
+  test('double-click spam on oracle draw does not break UI', async ({ page }) => {
+    await page.goto('/');
+    await page.getByTestId('aether-nav-oracle').click();
+    const draw = page.getByTestId('aether-oracle-draw');
+    await draw.dblclick();
+    await expect(page.getByTestId('aether-view-oracle')).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,12 @@
         "@commitlint/cli": "^18.0.0",
         "@commitlint/config-conventional": "^18.0.0",
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.2.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.0.0",
         "@vitest/coverage-v8": "^4.1.0",
         "autoprefixer": "^10.4.27",
@@ -1578,6 +1580,22 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
@@ -2630,6 +2648,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -7018,6 +7050,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "vitest run",
     "commitlint": "commitlint",
     "prepare": "husky install",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "lucide-react": "^0.577.0",
@@ -22,10 +24,12 @@
     "@commitlint/cli": "^18.0.0",
     "@commitlint/config-conventional": "^18.0.0",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.0.0",
     "@vitest/coverage-v8": "^4.1.0",
     "autoprefixer": "^10.4.27",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const isCI = !!process.env.CI;
+
+/**
+ * E2E against production-like preview (build + vite preview).
+ * In CI, run `npm run build` before `playwright test` — webServer only starts preview.
+ * @see docs/TESTIDS.md for stable selectors.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: isCI ? 1 : undefined,
+  reporter: isCI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: isCI
+      ? 'npm run preview -- --host 127.0.0.1 --port 4173 --strictPort'
+      : 'npm run build && npm run preview -- --host 127.0.0.1 --port 4173 --strictPort',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !isCI,
+    timeout: 120_000,
+  },
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,8 @@ import {
 /**
  * AETHER DECK - Modular TCG/Tarot System (v2.1 Glitchworks Edition)
  * Base App Component for glitchworks-tarot repo
+ *
+ * data-testid convention: `aether-<area>-<element>` — see docs/TESTIDS.md
  */
 
 // --- GLOBAL GLITCH STYLES ---
@@ -343,7 +345,7 @@ export default function App() {
 
   // --- VIEWS ---
   const renderDexView = () => (
-    <div className="p-4 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6 pb-24">
+    <div data-testid="aether-view-dex" className="p-4 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6 pb-24">
       {deck.map(card => (
         <div key={card.id} className="flex justify-center transform hover:-translate-y-2 transition-transform duration-300">
           <Card data={card} isFlipped={true} onClick={() => setSelectedCard(card)} />
@@ -353,7 +355,7 @@ export default function App() {
   );
 
   const renderArenaView = () => (
-    <div className="flex flex-col h-full p-4 max-w-4xl mx-auto">
+    <div data-testid="aether-view-arena" className="flex flex-col h-full p-4 max-w-4xl mx-auto">
       <div className="flex-1 flex flex-col md:flex-row items-center justify-center gap-8 my-4">
         
         {/* Alpha Slot */}
@@ -368,11 +370,13 @@ export default function App() {
 
         {/* Console / Controls */}
         <div className="flex flex-col items-center gap-4 z-10 w-full md:w-auto">
-          <div className={`w-full md:min-w-[240px] bg-black/80 backdrop-blur p-4 rounded border ${isClashing ? 'border-red-500 text-red-500' : 'border-white/10 text-indigo-300'} text-center transition-colors`}>
+          <div className={`w-full md:min-w-[240px] bg-black/80 backdrop-blur p-4 rounded border ${isClashing ? 'border-red-500 text-red-500' : 'border-white/10 text-indigo-300'} text-center transition-colors`} data-testid="aether-arena-log">
             <p className={`text-xs font-mono uppercase tracking-wider ${isClashing ? 'glitch-hover animate-pulse' : ''}`}>{battleLog}</p>
           </div>
           
           <button 
+            type="button"
+            data-testid="aether-arena-clash"
             onClick={resolveBattle} 
             disabled={!arenaSlots.p1 || !arenaSlots.p2 || isClashing}
             className={`w-full md:w-auto px-8 py-3 rounded-none border border-transparent font-bold tracking-widest transition-all ${
@@ -384,7 +388,7 @@ export default function App() {
             {isClashing ? 'PROCESSING...' : 'INITIATE CLASH'}
           </button>
           
-          <button onClick={clearArena} className="text-[10px] font-mono text-white/40 hover:text-white uppercase tracking-widest hover:bg-white/5 px-2 py-1 rounded">
+          <button type="button" data-testid="aether-arena-flush" onClick={clearArena} className="text-[10px] font-mono text-white/40 hover:text-white uppercase tracking-widest hover:bg-white/5 px-2 py-1 rounded">
             Flush_Memory
           </button>
         </div>
@@ -416,7 +420,7 @@ export default function App() {
   );
 
   const renderOracleView = () => (
-    <div className="flex flex-col items-center justify-center min-h-[80vh] gap-12 p-4">
+    <div data-testid="aether-view-oracle" className="flex flex-col items-center justify-center min-h-[80vh] gap-12 p-4">
       <div className="text-center space-y-2">
         <h2 className="text-3xl font-light text-indigo-300 glitch-text tracking-widest">THE ORACLE</h2>
         <p className="text-white/40 font-mono text-xs max-w-md mx-auto">Accessing probabilistic timelines...</p>
@@ -441,7 +445,7 @@ export default function App() {
         )}
       </div>
 
-      <button onClick={drawSpread} className="flex items-center gap-2 bg-indigo-900/50 border border-indigo-500 hover:bg-indigo-600 text-white px-8 py-3 rounded font-mono text-sm tracking-widest shadow-[0_0_20px_rgba(79,70,229,0.3)] transition-all active:scale-95 group">
+      <button type="button" data-testid="aether-oracle-draw" onClick={drawSpread} className="flex items-center gap-2 bg-indigo-900/50 border border-indigo-500 hover:bg-indigo-600 text-white px-8 py-3 rounded font-mono text-sm tracking-widest shadow-[0_0_20px_rgba(79,70,229,0.3)] transition-all active:scale-95 group">
         <Shuffle size={16} className="group-hover:animate-spin" />
         {spread.length > 0 ? 'RECALCULATE' : 'INITIALIZE SEQUENCE'}
       </button>
@@ -449,14 +453,14 @@ export default function App() {
   );
 
   const renderForgeView = () => (
-    <div className="flex flex-col lg:flex-row items-start justify-center gap-8 lg:gap-16 p-4 md:p-8 max-w-6xl mx-auto min-h-[80vh]">
+    <div data-testid="aether-view-forge" className="flex flex-col lg:flex-row items-start justify-center gap-8 lg:gap-16 p-4 md:p-8 max-w-6xl mx-auto min-h-[80vh]">
       <div className="flex flex-col items-center gap-6 lg:sticky lg:top-24 order-1 lg:order-2 w-full lg:w-auto">
         <div className="bg-emerald-900/20 border border-emerald-500/30 px-4 py-1 rounded text-emerald-400 font-mono text-[10px] tracking-widest uppercase flex items-center gap-2">
           <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse" />
           Live Preview
         </div>
         <Card data={forgeData} isFlipped={true} />
-        <button onClick={saveForgeCard} className="w-64 flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-500 text-white px-8 py-4 rounded font-bold font-mono text-sm tracking-widest shadow-[0_0_20px_rgba(16,185,129,0.5)] transition-all active:scale-95 hover:border-emerald-300 border border-transparent">
+        <button type="button" data-testid="aether-forge-compile" onClick={saveForgeCard} className="w-64 flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-500 text-white px-8 py-4 rounded font-bold font-mono text-sm tracking-widest shadow-[0_0_20px_rgba(16,185,129,0.5)] transition-all active:scale-95 hover:border-emerald-300 border border-transparent">
           <Save size={18} /> COMPILE ENTITY
         </button>
       </div>
@@ -540,16 +544,16 @@ export default function App() {
   );
 
   return (
-    <div className="min-h-screen bg-slate-950 text-white font-sans selection:bg-indigo-500/30 overflow-x-hidden">
+    <div data-testid="aether-root" className="min-h-screen bg-slate-950 text-white font-sans selection:bg-indigo-500/30 overflow-x-hidden">
       <GlitchStyles />
       <div className="noise-overlay"></div>
       <div className="crt-overlay"></div>
       
       {/* Settings Modal */}
       {showSettings && (
-        <div className="fixed inset-0 z-[99999] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4 animate-in fade-in">
-          <div className="bg-slate-900 border border-white/20 p-6 md:p-8 rounded-xl max-w-sm w-full shadow-2xl space-y-8 relative">
-            <button onClick={() => setShowSettings(false)} className="absolute top-4 right-4 text-white/50 hover:text-white">
+        <div data-testid="aether-modal-settings" className="fixed inset-0 z-[99999] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4 animate-in fade-in">
+          <div data-testid="aether-modal-settings-panel" className="bg-slate-900 border border-white/20 p-6 md:p-8 rounded-xl max-w-sm w-full shadow-2xl space-y-8 relative">
+            <button type="button" data-testid="aether-settings-close" onClick={() => setShowSettings(false)} className="absolute top-4 right-4 text-white/50 hover:text-white">
               <X size={24} />
             </button>
             <div>
@@ -566,14 +570,14 @@ export default function App() {
       )}
 
       {/* Nav */}
-      <nav className="fixed bottom-0 md:top-0 md:bottom-auto w-full z-50 bg-black/80 backdrop-blur-xl border-t md:border-b md:border-t-0 border-white/10 px-4 pt-3 pb-6 md:py-3 shadow-2xl">
+      <nav data-testid="aether-nav" className="fixed bottom-0 md:top-0 md:bottom-auto w-full z-50 bg-black/80 backdrop-blur-xl border-t md:border-b md:border-t-0 border-white/10 px-4 pt-3 pb-6 md:py-3 shadow-2xl">
         <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center gap-3 md:gap-0">
           <div className="flex w-full md:w-auto justify-between items-center">
             <div className="flex items-center gap-2 group cursor-pointer">
               <Layers className="text-indigo-500 group-hover:animate-spin" />
               <span className="font-bold tracking-tighter text-xl glitch-hover">GLITCH<span className="font-light text-white/50">WORKS</span></span>
             </div>
-            <button onClick={() => setShowSettings(true)} className="md:hidden text-white/50 hover:text-indigo-400 p-2">
+            <button type="button" data-testid="aether-settings-open" onClick={() => setShowSettings(true)} className="md:hidden text-white/50 hover:text-indigo-400 p-2">
               <Settings size={20} />
             </button>
           </div>
@@ -588,6 +592,8 @@ export default function App() {
                 { id: 'forge', icon: Hammer, color: 'emerald' }
               ].map(btn => (
                 <button 
+                  type="button"
+                  data-testid={`aether-nav-${btn.id}`}
                   key={btn.id}
                   onClick={() => setView(btn.id)} 
                   className={`shrink-0 px-4 md:px-5 py-2.5 rounded-full text-xs font-mono uppercase tracking-widest transition-all flex items-center gap-2 border ${
@@ -603,14 +609,14 @@ export default function App() {
               <div className="w-8 shrink-0 md:hidden" /> {/* Spacer to allow full scroll visibility */}
             </div>
             
-            <button onClick={() => setShowSettings(true)} className="hidden md:flex text-white/40 hover:text-indigo-400 p-2 ml-2 bg-slate-900/50 rounded-full border border-transparent hover:border-white/10 transition-colors">
+            <button type="button" data-testid="aether-settings-open-desktop" onClick={() => setShowSettings(true)} className="hidden md:flex text-white/40 hover:text-indigo-400 p-2 ml-2 bg-slate-900/50 rounded-full border border-transparent hover:border-white/10 transition-colors">
               <Settings size={18} />
             </button>
           </div>
         </div>
       </nav>
 
-      <main className="relative z-10 pt-4 md:pt-28 pb-32 md:pb-12 max-w-6xl mx-auto min-h-screen">
+      <main data-testid="aether-main" className="relative z-10 pt-4 md:pt-28 pb-32 md:pb-12 max-w-6xl mx-auto min-h-screen">
         {view === 'dex' && renderDexView()}
         {view === 'arena' && renderArenaView()}
         {view === 'oracle' && renderOracleView()}
@@ -619,9 +625,9 @@ export default function App() {
 
       {/* Card Details Modal */}
       {selectedCard && view === 'dex' && (
-        <div className="fixed inset-0 z-[900] flex items-center justify-center bg-black/90 backdrop-blur-md p-4 animate-in fade-in duration-200" onClick={() => setSelectedCard(null)}>
+        <div data-testid="aether-modal-card" className="fixed inset-0 z-[900] flex items-center justify-center bg-black/90 backdrop-blur-md p-4 animate-in fade-in duration-200" onClick={() => setSelectedCard(null)}>
           <div className="relative transform transition-transform animate-in zoom-in-95 duration-300" onClick={e => e.stopPropagation()}>
-            <button className="absolute -top-16 right-0 text-white/50 hover:text-white transition-colors bg-white/5 p-2 rounded-full border border-white/10" onClick={() => setSelectedCard(null)}>
+            <button type="button" data-testid="aether-modal-card-close" className="absolute -top-16 right-0 text-white/50 hover:text-white transition-colors bg-white/5 p-2 rounded-full border border-white/10" onClick={() => setSelectedCard(null)}>
               <X size={24} />
             </button>
             <Card data={selectedCard} isFlipped={true} size="lg" />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,9 +1,79 @@
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import App from './App.jsx';
 
 describe('App', () => {
-  it('renders without crashing', () => {
-    const { container } = render(<App />);
-    expect(container).toBeTruthy();
+  beforeEach(() => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.42);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders root shell and default dex view', () => {
+    render(<App />);
+    expect(screen.getByTestId('aether-root')).toBeInTheDocument();
+    expect(screen.getByTestId('aether-view-dex')).toBeInTheDocument();
+    expect(screen.getByTestId('aether-main')).toBeInTheDocument();
+  });
+
+  it('switches views when nav tabs are clicked', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    expect(screen.getByTestId('aether-view-dex')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('aether-nav-arena'));
+    expect(screen.queryByTestId('aether-view-dex')).not.toBeInTheDocument();
+    expect(screen.getByTestId('aether-view-arena')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('aether-nav-oracle'));
+    expect(screen.getByTestId('aether-view-oracle')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('aether-nav-forge'));
+    expect(screen.getByTestId('aether-view-forge')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('aether-nav-dex'));
+    expect(screen.getByTestId('aether-view-dex')).toBeInTheDocument();
+  });
+
+  it('opens and closes settings modal', () => {
+    render(<App />);
+    expect(screen.queryByTestId('aether-modal-settings')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('aether-settings-open-desktop'));
+    expect(screen.getByTestId('aether-modal-settings')).toBeInTheDocument();
+    expect(screen.getByTestId('aether-modal-settings-panel')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('aether-settings-close'));
+    expect(screen.queryByTestId('aether-modal-settings')).not.toBeInTheDocument();
+  });
+
+  it('opens card detail modal from dex and closes it', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    expect(screen.getByText('The Fool')).toBeInTheDocument();
+    await user.click(screen.getByText('The Fool'));
+
+    const modal = screen.getByTestId('aether-modal-card');
+    expect(modal).toBeInTheDocument();
+    expect(within(modal).getByText('The Fool')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('aether-modal-card-close'));
+    expect(screen.queryByTestId('aether-modal-card')).not.toBeInTheDocument();
+  });
+
+  it('oracle draw populates spread', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByTestId('aether-nav-oracle'));
+
+    expect(screen.getByTestId('aether-view-oracle')).toBeInTheDocument();
+    await user.click(screen.getByTestId('aether-oracle-draw'));
+
+    expect(screen.getByText('T-Minus (Past)')).toBeInTheDocument();
   });
 });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./src/setupTests.js'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
Brings **main** up to date with the Metapod **test shield** work plus **documentation** so the repo is self-explanatory for launch, testing, and spec location.

### Test shield (already on branch)
- Stable `data-testid` hooks + `docs/TESTIDS.md`
- Vitest + RTL (`setupTests`), expanded `App.test.jsx`
- Playwright E2E + CI `e2e` job; deploy gated to `main`/`master` push; deploy downloads build artifact
- `docs/AETHER_RAM.ipynb` (agent RAM + optional test output log)

### Docs (this PR)
- Expanded `README.md`: quick start, scripts, CI, doc map, `legacy-peer-deps`
- `docs/SPEC.md` — pointer to canonical v2.1 spec in dev-master
- `docs/TESTING.md` — methodology + commands
- `docs/README.md` — index of `docs/`

### Verify
```bash
npm ci --legacy-peer-deps
npm run lint && npm run test && npm run build
npm run test:e2e   # optional: playwright browsers
```

**Note:** Remote may redirect to `glitchworks-tarot` — same repo.


Made with [Cursor](https://cursor.com)