### PR TITLE
chore: align package and docs with glitchworks-tarot rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to glitchhub-tarot (Aether Deck) 🔮
+# Contributing to glitchworks-tarot (Aether Deck) 🔮
 
-Welcome! **glitchhub-tarot** is a dark-mode glitch-art tarot / TCG deck experience — modular card views (Dex, Arena, Oracle, Forge), dynamic deck data, and optional Android packaging via Capacitor.
+Welcome! **glitchworks-tarot** is a dark-mode glitch-art tarot / TCG deck experience — modular card views (Dex, Arena, Oracle, Forge), dynamic deck data, and optional Android packaging via Capacitor.
 
 For a quick product overview, see [README.md](./README.md). For stable E2E/RTL selectors, see [docs/TESTIDS.md](./docs/TESTIDS.md).
 
@@ -40,7 +40,7 @@ linear/              # Linear integration config
 
 ## 🌌 1. The Prime Directive: Pure Code in Submodules, Guides in Superproject
 
-This repository (`glitchhub-tarot`) is tracked as a git submodule within parent environments (such as the `dev-master` monorepo). We enforce a strict boundary between parent workspaces and this upstream codebase.
+This repository (`glitchworks-tarot`) is tracked as a git submodule within parent environments (such as the `dev-master` monorepo). We enforce a strict boundary between parent workspaces and this upstream codebase.
 
 ### ⚠️ The Boundary Violation Rule
 
@@ -58,7 +58,7 @@ This repository (`glitchhub-tarot`) is tracked as a git submodule within parent 
 
 ## 🏛️ 2. GlitchWorks Agnostic Architecture Protocol
 
-Every feature, integration, or refactor in `glitchhub-tarot` must be designed as an agnostic data pipeline. Core deck/oracle logic must not assume a specific deployment context or direct parent monorepo coupling.
+Every feature, integration, or refactor in `glitchworks-tarot` must be designed as an agnostic data pipeline. Core deck/oracle logic must not assume a specific deployment context or direct parent monorepo coupling.
 
 ### 2.1. Zero Hardcoding (Dynamic State Configuration)
 
@@ -109,7 +109,7 @@ Ensure you have configured both your personal fork (`origin`) and the official u
 git remote -v
 
 # If upstream is missing, configure it
-git remote add upstream https://github.com/k-dot-greyz/glitchhub-tarot.git
+git remote add upstream https://github.com/k-dot-greyz/glitchworks-tarot.git
 ```
 
 ### Step 2: Checkout a Fresh Branch
@@ -172,10 +172,10 @@ git push -u origin HEAD
 
 ### Step 6: Create Your Pull Request
 
-Submit your PR to `k-dot-greyz/glitchhub-tarot` `main`:
+Submit your PR to `k-dot-greyz/glitchworks-tarot` `main`:
 
 ```bash
-gh pr create --repo k-dot-greyz/glitchhub-tarot --base main \
+gh pr create --repo k-dot-greyz/glitchworks-tarot --base main \
   --title "feat(oracle): short summary" \
   --body "$(cat <<'EOF'
 ## Summary
@@ -190,7 +190,7 @@ EOF
 )"
 ```
 
-> **Note:** If `origin` already points at `k-dot-greyz/glitchhub-tarot` (no personal fork), push your branch to `origin` and open the PR the same way.
+> **Note:** If `origin` already points at `k-dot-greyz/glitchworks-tarot` (no personal fork), push your branch to `origin` and open the PR the same way.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# glitchhub-tarot (Glitchworks — Aether Deck)
+# glitchworks-tarot (Glitchworks — Aether Deck)
 
 Dark-mode **cyber-mystic** card UI: **Dex** (library), **Arena** (clash), **Oracle** (spread), **Forge** (entity builder). React 18 + Vite + Tailwind + lucide-react.
-
-> **Naming:** GitHub repo may appear as **glitchhub-tarot** or **glitchworks-tarot** — same app; check `git remote -v`.
 
 ## Quick start (launch)
 
@@ -49,7 +47,7 @@ GitHub Actions: **lint** → **Vitest + coverage** → **build** → **Playwrigh
 
 ## zenOS / dev-master
 
-When embedded in **dev-master**, this repo lives at `dex/09-repos/glitchhub-tarot`. Cross-repo scratchpad: root `AGENT_RAM.ipynb`; app-specific notes: `docs/AETHER_RAM.ipynb`.
+When embedded in **dev-master**, this repo lives at `dex/09-repos/glitchworks-tarot`. Cross-repo scratchpad: root `AGENT_RAM.ipynb`; app-specific notes: `docs/AETHER_RAM.ipynb`.
 
 ---
 

--- a/docs/AETHER_RAM.ipynb
+++ b/docs/AETHER_RAM.ipynb
@@ -4,18 +4,20 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# Aether / Metapod \u2014 repo-local agent RAM\n",
+        "# Aether / Metapod — repo-local agent RAM\n",
         "\n",
-        "- **Canonical remote:** `glitchhub-tarot` / **glitchworks-tarot** naming \u2014 check `origin` on this clone.\n",
+        "- **Canonical remote:** `glitchworks-tarot` (`origin` on this clone).\n",
         "- **Current wave:** test shield (`data-testid`, Vitest+RTL, Playwright, CI `e2e` job).\n",
         "- **Copy-paste:**\n",
-        "  - `npm run test` \u2014 unit/component\n",
-        "  - `npm run test:e2e` \u2014 Playwright (local: builds+preview; CI: build artifact + preview)\n",
-        "  - `npm run build && npm run preview` \u2014 manual smoke\n",
+        "  - `npm run test` — unit/component\n",
+        "  - `npm run test:e2e` — Playwright (local: builds+preview; CI: build artifact + preview)\n",
+        "  - `npm run build && npm run preview` — manual smoke\n",
         "- **Selectors:** [`docs/TESTIDS.md`](TESTIDS.md)\n",
         "\n",
-        "Keep this notebook **small**; long lore lives in `dex/03-docs/` on dev-master.\n"
-      ]
+        "Keep this notebook **small**; long lore lives in `dex/03-docs/` on dev-master.\n",
+        ""
+      ],
+      "id": "f7889a80"
     },
     {
       "cell_type": "markdown",
@@ -23,11 +25,11 @@
       "source": [
         "## Test results log (progress)\n",
         "\n",
-        "**How this works:** Run the Python cells below. When you **Save** the notebook, Jupyter stores **outputs** inside this `.ipynb` file \u2014 so you get a lightweight, commit-friendly history of \u201cwhat passed when.\u201d\n",
+        "**How this works:** Run the Python cells below. When you **Save** the notebook, Jupyter stores **outputs** inside this `.ipynb` file — so you get a lightweight, commit-friendly history of “what passed when.”\n",
         "\n",
-        "- Prefer committing after a green run (or after a deliberate \u201cred\u201d snapshot you care about).\n",
+        "- Prefer committing after a green run (or after a deliberate “red” snapshot you care about).\n",
         "- **Vitest** is fast; **E2E** needs Playwright browsers installed (`npx playwright install chromium`).\n",
-        "- If the kernel\u2019s cwd is wrong, cells resolve the repo root automatically (`package.json` next to `src/`).\n"
+        "- If the kernel’s cwd is wrong, cells resolve the repo root automatically (`package.json` next to `src/`).\n"
       ]
     },
     {
@@ -44,8 +46,6 @@
           "aether-tests-vitest"
         ]
       },
-      "execution_count": null,
-      "outputs": [],
       "source": [
         "# Run Vitest; output is captured below when you execute + save the notebook.\n",
         "import subprocess\n",
@@ -59,7 +59,7 @@
         "        return here\n",
         "    if (here.parent / \"package.json\").exists():\n",
         "        return here.parent\n",
-        "    raise FileNotFoundError(\"Start Jupyter from repo root or from docs/ \u2014 could not find package.json\")\n",
+        "    raise FileNotFoundError(\"Start Jupyter from repo root or from docs/ — could not find package.json\")\n",
         "\n",
         "ROOT = repo_root()\n",
         "stamp = datetime.now(timezone.utc).strftime(\"%Y-%m-%d %H:%M:%S UTC\")\n",
@@ -79,7 +79,9 @@
         "print(f\"\\n[exit code {proc.returncode}]\")\n",
         "if proc.returncode != 0:\n",
         "    raise RuntimeError(f\"Vitest failed with exit code {proc.returncode}\")\n"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -97,8 +99,6 @@
           "aether-tests-e2e"
         ]
       },
-      "execution_count": null,
-      "outputs": [],
       "source": [
         "import os\n",
         "import subprocess\n",
@@ -135,13 +135,15 @@
         "print(f\"\\n[exit code {proc.returncode}]\")\n",
         "if proc.returncode != 0:\n",
         "    raise RuntimeError(f\"Playwright failed with exit code {proc.returncode}\")\n"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Manual paste \u2014 CI / PR / ad-hoc\n",
+        "### Manual paste — CI / PR / ad-hoc\n",
         "\n",
         "Paste GitHub Actions snippets, PR links, or notes here (static text; no execution):\n",
         "\n",

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -4,7 +4,7 @@ The **authoritative product/spec document** for Glitchworks / Aether Deck lives 
 
 | Context | Path |
 |---------|------|
-| **dev-master monorepo** | [`dex/08-projects/Glitchworks Tarot-Aether Deck Spec.md`](../../../08-projects/Glitchworks%20Tarot-Aether%20Deck%20Spec.md) (relative from this file: `dex/09-repos/glitchhub-tarot/docs/` → go up to `dex/` then `08-projects/`) |
+| **dev-master monorepo** | [`dex/08-projects/Glitchworks Tarot-Aether Deck Spec.md`](../../../08-projects/Glitchworks%20Tarot-Aether%20Deck%20Spec.md) (relative from this file: `dex/09-repos/glitchworks-tarot/docs/` → go up to `dex/` then `08-projects/`) |
 | **Submodule path** (this repo) | [`../dev-master/08-projects/Glitchworks Tarot-Aether Deck Spec.md`](../dev-master/08-projects/Glitchworks%20Tarot-Aether%20Deck%20Spec.md) — works after `git submodule update --init` |
 | **Standalone clone** of this repo only | > ⚠️ Standalone clone: link unavailable — see dev-master. Open the same file on GitHub from **dev-master**, or copy the spec into your wiki — the app repo does not vendor the full spec by default. |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "glitchhub-tarot",
+  "name": "glitchworks-tarot",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "glitchhub-tarot",
+      "name": "glitchworks-tarot",
       "version": "1.0.0",
       "dependencies": {
         "@capacitor/android": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "glitchhub-tarot",
+  "name": "glitchworks-tarot",
   "version": "1.0.0",
   "description": "Dark mode glitch art tarot card generator - dev-master setup",
   "main": "src/main.jsx",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -323,7 +323,7 @@ export default function App() {
       const p1Score = (arenaSlots.p1.stats.atk + arenaSlots.p1.stats.spd) * p1Advantage;
       const p2Score = (arenaSlots.p2.stats.atk + arenaSlots.p2.stats.spd) * p2Advantage;
       
-      let result = "";
+      let result;
       if (p1Score > p2Score) {
         result = `> ${arenaSlots.p1.name.toUpperCase()} OVERWRITES ${arenaSlots.p2.name.toUpperCase()}${p1Advantage > 1.0 ? " (TYPE_ADVANTAGE)" : ""}`;
       } else if (p2Score > p1Score) {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/setupTests.js'],
+    exclude: ['**/node_modules/**', '**/e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- Rename npm package from `glitchhub-tarot` to `glitchworks-tarot`
- Update README, CONTRIBUTING, SPEC, and AETHER_RAM paths to match the GitHub rename and dev-master submodule path (`dex/09-repos/glitchworks-tarot`)

## Context
`glitchhub-tarot` was renamed to `glitchworks-tarot` on GitHub. PR #7 (CONTRIBUTING) is merged; this finishes the naming alignment in-repo.

## Test plan
- [ ] `npm ci --legacy-peer-deps`
- [ ] `npm run lint`
- [ ] `npm run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project branding and repository references from "glitchhub-tarot" to "glitchworks-tarot" across all documentation files.
  * Updated contribution guidelines and workflow instructions to reflect the new repository structure.
  * Clarified deck specification pointers in supporting documentation.

* **Chores**
  * Updated package manifest with new project name.
  * Cleaned up notebook metadata for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->