### PR TITLE
feat(arena): decouple battle engine and add arena modes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import { GlitchStyles } from './components/GlitchStyles.jsx';
 import { NeonSlider } from './components/NeonSlider.jsx';
 import { Card } from './components/Card.jsx';
 import { usePersistedDeck } from './hooks/usePersistedDeck.js';
-import { resolveBattle } from './domain/battle.js';
+import { resolveBattleWithEngine, arenaModes } from './domain/battleEngine.js';
 import { drawSpread } from './domain/deckState.js';
 import { createLocalStorageDeckStorage } from './adapters/localStorageDeckStorage.js';
 import { createConsoleTelemetry } from './adapters/consoleTelemetry.js';
@@ -36,6 +36,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
   const [arenaSlots, setArenaSlots] = useState({ p1: null, p2: null });
   const [battleLog, setBattleLog] = useState("[ WAITING FOR DATA INPUT ]");
   const [isClashing, setIsClashing] = useState(false);
+  const [arenaMode, setArenaMode] = useState('standard');
 
   // Oracle State
   const [spread, setSpread] = useState([]);
@@ -75,21 +76,39 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
     if (isClashing) return;
     if (!arenaSlots.p1) {
       setArenaSlots({ ...arenaSlots, p1: card });
-      setBattleLog("[ ALPHA SLOT FILLED ]");
+      setBattleLog(
+        arenaMode === 'combatDisabled'
+          ? '> SYSTEMS IN HARMONY. NO CLASH POSSIBLE.'
+          : '[ ALPHA SLOT FILLED ]',
+      );
     } else if (!arenaSlots.p2) {
       setArenaSlots({ ...arenaSlots, p2: card });
-      setBattleLog("[ READY FOR COLLISION ]");
+      setBattleLog(
+        arenaMode === 'combatDisabled'
+          ? '> SYSTEMS IN HARMONY. NO CLASH POSSIBLE.'
+          : '[ READY FOR COLLISION ]',
+      );
     }
   };
 
   const handleResolveBattle = () => {
-    if (!arenaSlots.p1 || !arenaSlots.p2 || isClashing) return;
-    
+    if (
+      !arenaSlots.p1 ||
+      !arenaSlots.p2 ||
+      isClashing ||
+      arenaMode === 'combatDisabled'
+    )
+      return;
+
     setIsClashing(true);
     setBattleLog("[ ERR: DATA COLLISION DETECTED ]");
 
     setTimeout(() => {
-      const result = resolveBattle(arenaSlots.p1, arenaSlots.p2);
+      const result = resolveBattleWithEngine(
+        arenaSlots.p1,
+        arenaSlots.p2,
+        arenaMode,
+      );
       setBattleLog(result.logLine);
       setIsClashing(false);
     }, 600);
@@ -98,7 +117,11 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
   const clearArena = () => {
     if (isClashing) return;
     setArenaSlots({ p1: null, p2: null });
-    setBattleLog("[ ARENA WIPED ]");
+    setBattleLog(
+      arenaMode === 'combatDisabled'
+        ? '> SYSTEMS IN HARMONY. NO CLASH POSSIBLE.'
+        : '[ ARENA WIPED ]',
+    );
   };
 
   const handleDrawSpread = () => {
@@ -134,62 +157,151 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
   );
 
   const renderArenaView = () => (
-    <div data-testid="aether-view-arena" className="flex flex-col h-full p-4 max-w-4xl mx-auto">
+    <div
+      data-testid="aether-view-arena"
+      className="flex flex-col h-full p-4 max-w-4xl mx-auto"
+    >
       <div className="flex-1 flex flex-col md:flex-row items-center justify-center gap-8 my-4">
-        
         {/* Alpha Slot */}
         <div className="flex flex-col items-center gap-2">
-          <span className="text-indigo-400 font-mono text-xs tracking-widest glitch-text">ALPHA SLOT</span>
+          <span className="text-indigo-400 font-mono text-xs tracking-widest glitch-text">
+            ALPHA SLOT
+          </span>
           {arenaSlots.p1 ? (
-            <Card data={arenaSlots.p1} isFlipped={true} clashing={isClashing} onClick={() => setArenaSlots({...arenaSlots, p1: null})} />
+            <Card
+              data={arenaSlots.p1}
+              isFlipped={true}
+              clashing={isClashing}
+              onClick={() => setArenaSlots({ ...arenaSlots, p1: null })}
+            />
           ) : (
-            <div className="w-64 h-[28rem] rounded-xl border-2 border-dashed border-indigo-500/20 bg-indigo-900/10 flex items-center justify-center text-indigo-400/30 font-mono text-sm">AWAITING_DATA</div>
+            <div className="w-64 h-[28rem] rounded-xl border-2 border-dashed border-indigo-500/20 bg-indigo-900/10 flex items-center justify-center text-indigo-400/30 font-mono text-sm">
+              AWAITING_DATA
+            </div>
           )}
         </div>
 
         {/* Console / Controls */}
         <div className="flex flex-col items-center gap-4 z-10 w-full md:w-auto">
-          <div className={`w-full md:min-w-[240px] bg-black/80 backdrop-blur p-4 rounded border ${isClashing ? 'border-red-500 text-red-500' : 'border-white/10 text-indigo-300'} text-center transition-colors`} data-testid="aether-arena-log">
-            <p className={`text-xs font-mono uppercase tracking-wider ${isClashing ? 'glitch-hover animate-pulse' : ''}`}>{battleLog}</p>
+          <div
+            className={`w-full md:min-w-[240px] bg-black/80 backdrop-blur p-4 rounded border ${isClashing ? 'border-red-500 text-red-500' : 'border-white/10 text-indigo-300'} text-center transition-colors`}
+            data-testid="aether-arena-log"
+          >
+            <p
+              className={`text-xs font-mono uppercase tracking-wider ${isClashing ? 'glitch-hover animate-pulse' : ''}`}
+            >
+              {battleLog}
+            </p>
           </div>
-          
-          <button 
+
+          {/* Arena Mode Selector */}
+          <div className="w-full md:min-w-[240px] flex flex-col gap-1.5">
+            <label className="text-[10px] font-mono text-indigo-400/70 uppercase tracking-widest text-center">
+              Arena Mode
+            </label>
+            <select
+              data-testid="aether-arena-mode-select"
+              value={arenaMode}
+              onChange={(e) => {
+                const selectedMode = e.target.value;
+                setArenaMode(selectedMode);
+                if (selectedMode === 'combatDisabled') {
+                  setBattleLog('> SYSTEMS IN HARMONY. NO CLASH POSSIBLE.');
+                } else {
+                  setBattleLog(
+                    arenaSlots.p1 && arenaSlots.p2
+                      ? '[ READY FOR COLLISION ]'
+                      : '[ WAITING FOR DATA INPUT ]',
+                  );
+                }
+              }}
+              className="w-full bg-slate-900/80 border border-white/10 rounded px-3 py-2 text-white font-mono text-xs focus:outline-none focus:border-indigo-500 text-center appearance-none cursor-pointer"
+            >
+              {Object.values(arenaModes).map((mode) => (
+                <option key={mode.id} value={mode.id}>
+                  {mode.name.toUpperCase()}
+                </option>
+              ))}
+            </select>
+            <p className="text-[9px] font-mono text-white/30 text-center max-w-[240px]">
+              {arenaModes[arenaMode]?.description}
+            </p>
+          </div>
+
+          <button
             type="button"
             data-testid="aether-arena-clash"
-            onClick={handleResolveBattle} 
-            disabled={!arenaSlots.p1 || !arenaSlots.p2 || isClashing}
+            onClick={handleResolveBattle}
+            disabled={
+              !arenaSlots.p1 ||
+              !arenaSlots.p2 ||
+              isClashing ||
+              arenaMode === 'combatDisabled'
+            }
             className={`w-full md:w-auto px-8 py-3 rounded-none border border-transparent font-bold tracking-widest transition-all ${
-              isClashing ? 'bg-white text-black animate-pulse' : 
-              (!arenaSlots.p1 || !arenaSlots.p2) ? 'bg-slate-800 text-white/30 cursor-not-allowed' : 
-              'bg-red-600 hover:bg-red-500 text-white shadow-[0_0_20px_rgba(220,38,38,0.5)] hover:border-red-400'
+              isClashing
+                ? 'bg-white text-black animate-pulse'
+                : !arenaSlots.p1 ||
+                    !arenaSlots.p2 ||
+                    arenaMode === 'combatDisabled'
+                  ? 'bg-slate-800 text-white/30 cursor-not-allowed'
+                  : 'bg-red-600 hover:bg-red-500 text-white shadow-[0_0_20px_rgba(220,38,38,0.5)] hover:border-red-400'
             }`}
           >
-            {isClashing ? 'PROCESSING...' : 'INITIATE CLASH'}
+            {isClashing
+              ? 'PROCESSING...'
+              : arenaMode === 'combatDisabled'
+                ? 'COMBAT DISABLED'
+                : 'INITIATE CLASH'}
           </button>
-          
-          <button type="button" data-testid="aether-arena-flush" onClick={clearArena} className="text-[10px] font-mono text-white/40 hover:text-white uppercase tracking-widest hover:bg-white/5 px-2 py-1 rounded">
+
+          <button
+            type="button"
+            data-testid="aether-arena-flush"
+            onClick={clearArena}
+            className="text-[10px] font-mono text-white/40 hover:text-white uppercase tracking-widest hover:bg-white/5 px-2 py-1 rounded"
+          >
             Flush_Memory
           </button>
         </div>
 
         {/* Omega Slot */}
         <div className="flex flex-col items-center gap-2">
-          <span className="text-red-400 font-mono text-xs tracking-widest glitch-text">OMEGA SLOT</span>
+          <span className="text-red-400 font-mono text-xs tracking-widest glitch-text">
+            OMEGA SLOT
+          </span>
           {arenaSlots.p2 ? (
-            <Card data={arenaSlots.p2} isFlipped={true} clashing={isClashing} onClick={() => setArenaSlots({...arenaSlots, p2: null})} />
+            <Card
+              data={arenaSlots.p2}
+              isFlipped={true}
+              clashing={isClashing}
+              onClick={() => setArenaSlots({ ...arenaSlots, p2: null })}
+            />
           ) : (
-            <div className="w-64 h-[28rem] rounded-xl border-2 border-dashed border-red-500/20 bg-red-900/10 flex items-center justify-center text-red-400/30 font-mono text-sm">AWAITING_DATA</div>
+            <div className="w-64 h-[28rem] rounded-xl border-2 border-dashed border-red-500/20 bg-red-900/10 flex items-center justify-center text-red-400/30 font-mono text-sm">
+              AWAITING_DATA
+            </div>
           )}
         </div>
       </div>
 
       {/* Bench */}
       <div className="mt-auto pt-4 border-t border-white/10 bg-black/20">
-        <p className="text-[10px] text-white/30 font-mono text-center mb-2 uppercase">Local_Storage_Array</p>
+        <p className="text-[10px] text-white/30 font-mono text-center mb-2 uppercase">
+          Local_Storage_Array
+        </p>
         <div className="overflow-x-auto hide-scrollbar flex items-center gap-4 px-4 pb-4 [mask-image:linear-gradient(to_right,black_90%,transparent_100%)]">
-          {deck.map(card => (
-            <div key={card.id} className={`shrink-0 scale-75 origin-bottom hover:scale-90 transition-transform ${arenaSlots.p1?.id === card.id || arenaSlots.p2?.id === card.id ? 'opacity-20 pointer-events-none' : ''}`}>
-              <Card data={card} isFlipped={true} onClick={() => handleArenaSelect(card)} size="sm" />
+          {deck.map((card) => (
+            <div
+              key={card.id}
+              className={`shrink-0 scale-75 origin-bottom hover:scale-90 transition-transform ${arenaSlots.p1?.id === card.id || arenaSlots.p2?.id === card.id ? 'opacity-20 pointer-events-none' : ''}`}
+            >
+              <Card
+                data={card}
+                isFlipped={true}
+                onClick={() => handleArenaSelect(card)}
+                size="sm"
+              />
             </div>
           ))}
           <div className="w-12 shrink-0" /> {/* Spacer for scroll mask */}
@@ -204,7 +316,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
         <h2 className="text-3xl font-light text-indigo-300 glitch-text tracking-widest">THE ORACLE</h2>
         <p className="text-white/40 font-mono text-xs max-w-md mx-auto">Accessing probabilistic timelines...</p>
       </div>
-      
+
       <div className="flex flex-col md:flex-row gap-8 lg:gap-12 perspective-1000">
         {spread.length > 0 ? (
           spread.map((card, index) => (
@@ -232,14 +344,22 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
   );
 
   const renderForgeView = () => (
-    <div data-testid="aether-view-forge" className="flex flex-col lg:flex-row items-start justify-center gap-8 lg:gap-16 p-4 md:p-8 max-w-6xl mx-auto min-h-[80vh]">
+    <div
+      data-testid="aether-view-forge"
+      className="flex flex-col lg:flex-row items-start justify-center gap-8 lg:gap-16 p-4 md:p-8 max-w-6xl mx-auto min-h-[80vh]"
+    >
       <div className="flex flex-col items-center gap-6 lg:sticky lg:top-24 order-1 lg:order-2 w-full lg:w-auto">
         <div className="bg-emerald-900/20 border border-emerald-500/30 px-4 py-1 rounded text-emerald-400 font-mono text-[10px] tracking-widest uppercase flex items-center gap-2">
           <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse" />
           Live Preview
         </div>
         <Card data={forgeData} isFlipped={true} />
-        <button type="button" data-testid="aether-forge-compile" onClick={saveForgeCard} className="w-64 flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-500 text-white px-8 py-4 rounded font-bold font-mono text-sm tracking-widest shadow-[0_0_20px_rgba(16,185,129,0.5)] transition-all active:scale-95 hover:border-emerald-300 border border-transparent">
+        <button
+          type="button"
+          data-testid="aether-forge-compile"
+          onClick={saveForgeCard}
+          className="w-64 flex items-center justify-center gap-2 bg-emerald-600 hover:bg-emerald-500 text-white px-8 py-4 rounded font-bold font-mono text-sm tracking-widest shadow-[0_0_20px_rgba(16,185,129,0.5)] transition-all active:scale-95 hover:border-emerald-300 border border-transparent"
+        >
           <Save size={18} /> COMPILE ENTITY
         </button>
       </div>
@@ -247,72 +367,189 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
       <div className="w-full max-w-md space-y-8 bg-black/60 backdrop-blur-md p-6 md:p-8 rounded-xl border border-white/10 order-2 lg:order-1 shadow-2xl">
         <div className="flex items-center gap-3 border-b border-white/10 pb-4">
           <Hammer className="text-emerald-400" />
-          <h2 className="text-xl font-light tracking-widest uppercase glitch-text">The Forge</h2>
+          <h2 className="text-xl font-light tracking-widest uppercase glitch-text">
+            The Forge
+          </h2>
         </div>
 
         <div className="space-y-5">
           <div>
-            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">Entity Designation</label>
-            <input type="text" value={forgeData.name} onChange={e => setForgeData({...forgeData, name: e.target.value})} className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-bold focus:outline-none focus:border-emerald-500 focus:bg-slate-800 transition-colors" />
+            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">
+              Entity Designation
+            </label>
+            <input
+              type="text"
+              value={forgeData.name}
+              onChange={(e) =>
+                setForgeData({ ...forgeData, name: e.target.value })
+              }
+              className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-bold focus:outline-none focus:border-emerald-500 focus:bg-slate-800 transition-colors"
+            />
           </div>
           <div>
-            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">Archetype Class</label>
-            <input type="text" value={forgeData.sub} onChange={e => setForgeData({...forgeData, sub: e.target.value})} className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white focus:outline-none focus:border-emerald-500 focus:bg-slate-800 transition-colors text-sm" />
+            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">
+              Archetype Class
+            </label>
+            <input
+              type="text"
+              value={forgeData.sub}
+              onChange={(e) =>
+                setForgeData({ ...forgeData, sub: e.target.value })
+              }
+              className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white focus:outline-none focus:border-emerald-500 focus:bg-slate-800 transition-colors text-sm"
+            />
           </div>
         </div>
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">Elemental Core</label>
-            <select value={forgeData.type} onChange={e => setForgeData({...forgeData, type: e.target.value})} className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-mono text-xs focus:outline-none focus:border-emerald-500 appearance-none">
-              {['void', 'fire', 'water', 'electric', 'wind', 'dark'].map(t => <option key={t} value={t}>{t.toUpperCase()}</option>)}
+            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">
+              Elemental Core
+            </label>
+            <select
+              value={forgeData.type}
+              onChange={(e) =>
+                setForgeData({ ...forgeData, type: e.target.value })
+              }
+              className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-mono text-xs focus:outline-none focus:border-emerald-500 appearance-none"
+            >
+              {['void', 'fire', 'water', 'electric', 'wind', 'dark'].map(
+                (t) => (
+                  <option key={t} value={t}>
+                    {t.toUpperCase()}
+                  </option>
+                ),
+              )}
             </select>
           </div>
           <div>
-            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">Visual Sigil</label>
-            <select value={forgeData.icon} onChange={e => setForgeData({...forgeData, icon: e.target.value})} className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-mono text-xs focus:outline-none focus:border-emerald-500 appearance-none">
-              {['Sparkles', 'Flame', 'Droplets', 'Zap', 'Skull', 'Wind', 'Eye', 'Star', 'Sword', 'Shield', 'Hammer'].map(k => <option key={k} value={k}>{k.toUpperCase()}</option>)}
+            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">
+              Visual Sigil
+            </label>
+            <select
+              value={forgeData.icon}
+              onChange={(e) =>
+                setForgeData({ ...forgeData, icon: e.target.value })
+              }
+              className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-mono text-xs focus:outline-none focus:border-emerald-500 appearance-none"
+            >
+              {[
+                'Sparkles',
+                'Flame',
+                'Droplets',
+                'Zap',
+                'Skull',
+                'Wind',
+                'Eye',
+                'Star',
+                'Sword',
+                'Shield',
+                'Hammer',
+              ].map((k) => (
+                <option key={k} value={k}>
+                  {k.toUpperCase()}
+                </option>
+              ))}
             </select>
           </div>
         </div>
 
         <div className="space-y-6 bg-slate-900/50 border border-white/5 p-5 rounded-lg">
-          <NeonSlider label="ATK_POTENTIAL" value={forgeData.stats.atk} color="red" onChange={v => setForgeData({...forgeData, stats: {...forgeData.stats, atk: v}})} />
-          <NeonSlider label="DEF_RESILIENCE" value={forgeData.stats.def} color="indigo" onChange={v => setForgeData({...forgeData, stats: {...forgeData.stats, def: v}})} />
-          <NeonSlider label="SPD_AGILITY" value={forgeData.stats.spd} color="emerald" onChange={v => setForgeData({...forgeData, stats: {...forgeData.stats, spd: v}})} />
+          <NeonSlider
+            label="ATK_POTENTIAL"
+            value={forgeData.stats.atk}
+            color="red"
+            onChange={(v) =>
+              setForgeData({
+                ...forgeData,
+                stats: { ...forgeData.stats, atk: v },
+              })
+            }
+          />
+          <NeonSlider
+            label="DEF_RESILIENCE"
+            value={forgeData.stats.def}
+            color="indigo"
+            onChange={(v) =>
+              setForgeData({
+                ...forgeData,
+                stats: { ...forgeData.stats, def: v },
+              })
+            }
+          />
+          <NeonSlider
+            label="SPD_AGILITY"
+            value={forgeData.stats.spd}
+            color="emerald"
+            onChange={(v) =>
+              setForgeData({
+                ...forgeData,
+                stats: { ...forgeData.stats, spd: v },
+              })
+            }
+          />
         </div>
 
         <div>
-          <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">Lore Injection</label>
-          <textarea rows="3" value={forgeData.desc} onChange={e => setForgeData({...forgeData, desc: e.target.value})} className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white/70 text-sm italic font-serif focus:outline-none focus:border-emerald-500 transition-colors resize-none" />
+          <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">
+            Lore Injection
+          </label>
+          <textarea
+            rows="3"
+            value={forgeData.desc}
+            onChange={(e) =>
+              setForgeData({ ...forgeData, desc: e.target.value })
+            }
+            className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white/70 text-sm italic font-serif focus:outline-none focus:border-emerald-500 transition-colors resize-none"
+          />
         </div>
 
         <div className="border-t border-white/10 pt-5 space-y-4">
-          <label className="block text-[10px] font-mono text-emerald-500/70 uppercase tracking-widest">Presentation Override</label>
-          
+          <label className="block text-[10px] font-mono text-emerald-500/70 uppercase tracking-widest">
+            Presentation Override
+          </label>
+
           <div className="flex gap-4">
-            <button 
-              onClick={() => setForgeData({...forgeData, hideDesc: !forgeData.hideDesc})}
+            <button
+              onClick={() =>
+                setForgeData({ ...forgeData, hideDesc: !forgeData.hideDesc })
+              }
               className={`flex-1 flex items-center justify-center gap-2 py-2 border rounded font-mono text-xs transition-colors ${forgeData.hideDesc ? 'border-red-500/50 text-red-400 bg-red-900/20' : 'border-white/10 text-white/50 hover:border-emerald-500/50 hover:text-emerald-400'}`}
             >
-              {forgeData.hideDesc ? <EyeOff size={14}/> : <Eye size={14}/>} {forgeData.hideDesc ? 'LORE HIDDEN' : 'LORE VISIBLE'}
+              {forgeData.hideDesc ? <EyeOff size={14} /> : <Eye size={14} />}{' '}
+              {forgeData.hideDesc ? 'LORE HIDDEN' : 'LORE VISIBLE'}
             </button>
-            <button 
-              onClick={() => setForgeData({...forgeData, hideStats: !forgeData.hideStats})}
+            <button
+              onClick={() =>
+                setForgeData({ ...forgeData, hideStats: !forgeData.hideStats })
+              }
               className={`flex-1 flex items-center justify-center gap-2 py-2 border rounded font-mono text-xs transition-colors ${forgeData.hideStats ? 'border-red-500/50 text-red-400 bg-red-900/20' : 'border-white/10 text-white/50 hover:border-emerald-500/50 hover:text-emerald-400'}`}
             >
-              {forgeData.hideStats ? <EyeOff size={14}/> : <Eye size={14}/>} {forgeData.hideStats ? 'STATS HIDDEN' : 'STATS VISIBLE'}
+              {forgeData.hideStats ? <EyeOff size={14} /> : <Eye size={14} />}{' '}
+              {forgeData.hideStats ? 'STATS HIDDEN' : 'STATS VISIBLE'}
             </button>
           </div>
 
           <div>
             <label className="flex items-center justify-center gap-2 w-full bg-slate-900/50 border border-dashed border-emerald-500/30 hover:border-emerald-500 rounded px-3 py-4 text-emerald-400/70 hover:text-emerald-400 font-mono text-xs cursor-pointer transition-colors">
               <Upload size={16} />
-              {forgeData.customImage ? 'REPLACE CUSTOM ARTWORK' : 'UPLOAD CUSTOM ARTWORK'}
-              <input type="file" accept="image/*" onChange={handleImageUpload} className="hidden" />
+              {forgeData.customImage
+                ? 'REPLACE CUSTOM ARTWORK'
+                : 'UPLOAD CUSTOM ARTWORK'}
+              <input
+                type="file"
+                accept="image/*"
+                onChange={handleImageUpload}
+                className="hidden"
+              />
             </label>
             {forgeData.customImage && (
-              <button onClick={() => setForgeData({...forgeData, customImage: null})} className="w-full mt-2 text-center text-[10px] font-mono text-red-400/70 hover:text-red-400 uppercase tracking-widest">
+              <button
+                onClick={() =>
+                  setForgeData({ ...forgeData, customImage: null })
+                }
+                className="w-full mt-2 text-center text-[10px] font-mono text-red-400/70 hover:text-red-400 uppercase tracking-widest"
+              >
                 Remove Artwork
               </button>
             )}
@@ -323,44 +560,87 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
   );
 
   return (
-    <div data-testid="aether-root" className="min-h-screen bg-slate-950 text-white font-sans selection:bg-indigo-500/30 overflow-x-hidden">
+    <div
+      data-testid="aether-root"
+      className="min-h-screen bg-slate-950 text-white font-sans selection:bg-indigo-500/30 overflow-x-hidden"
+    >
       <GlitchStyles />
       <div className="noise-overlay"></div>
       <div className="crt-overlay"></div>
-      
+
       {/* Settings Modal */}
       {showSettings && (
-        <div data-testid="aether-modal-settings" className="fixed inset-0 z-[99999] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4 animate-in fade-in">
-          <div data-testid="aether-modal-settings-panel" className="bg-slate-900 border border-white/20 p-6 md:p-8 rounded-xl max-w-sm w-full shadow-2xl space-y-8 relative">
-            <button type="button" data-testid="aether-settings-close" onClick={() => setShowSettings(false)} className="absolute top-4 right-4 text-white/50 hover:text-white">
+        <div
+          data-testid="aether-modal-settings"
+          className="fixed inset-0 z-[99999] flex items-center justify-center bg-black/80 backdrop-blur-sm p-4 animate-in fade-in"
+        >
+          <div
+            data-testid="aether-modal-settings-panel"
+            className="bg-slate-900 border border-white/20 p-6 md:p-8 rounded-xl max-w-sm w-full shadow-2xl space-y-8 relative"
+          >
+            <button
+              type="button"
+              data-testid="aether-settings-close"
+              onClick={() => setShowSettings(false)}
+              className="absolute top-4 right-4 text-white/50 hover:text-white"
+            >
               <X size={24} />
             </button>
             <div>
-              <h3 className="text-xl font-light tracking-widest glitch-text mb-1">SYSTEM_CFG</h3>
-              <p className="text-xs font-mono text-white/40">Adjust UI degradation levels</p>
+              <h3 className="text-xl font-light tracking-widest glitch-text mb-1">
+                SYSTEM_CFG
+              </h3>
+              <p className="text-xs font-mono text-white/40">
+                Adjust UI degradation levels
+              </p>
             </div>
             <div className="space-y-6">
-              <NeonSlider label="GLITCH_INTENSITY" value={aesthetics.glitch} color="indigo" onChange={v => setAesthetics(s => ({...s, glitch: v}))} />
-              <NeonSlider label="CRT_SCANLINES" value={aesthetics.crt} color="emerald" onChange={v => setAesthetics(s => ({...s, crt: v}))} />
-              <NeonSlider label="GRAIN_NOISE" value={aesthetics.noise} color="red" onChange={v => setAesthetics(s => ({...s, noise: v}))} />
+              <NeonSlider
+                label="GLITCH_INTENSITY"
+                value={aesthetics.glitch}
+                color="indigo"
+                onChange={(v) => setAesthetics((s) => ({ ...s, glitch: v }))}
+              />
+              <NeonSlider
+                label="CRT_SCANLINES"
+                value={aesthetics.crt}
+                color="emerald"
+                onChange={(v) => setAesthetics((s) => ({ ...s, crt: v }))}
+              />
+              <NeonSlider
+                label="GRAIN_NOISE"
+                value={aesthetics.noise}
+                color="red"
+                onChange={(v) => setAesthetics((s) => ({ ...s, noise: v }))}
+              />
             </div>
           </div>
         </div>
       )}
 
       {/* Nav */}
-      <nav data-testid="aether-nav" className="fixed bottom-0 md:top-0 md:bottom-auto w-full z-50 bg-black/80 backdrop-blur-xl border-t md:border-b md:border-t-0 border-white/10 px-4 pt-3 pb-[calc(1.5rem+var(--safe-area-inset-bottom))] md:py-3 shadow-2xl">
+      <nav
+        data-testid="aether-nav"
+        className="fixed bottom-0 md:top-0 md:bottom-auto w-full z-50 bg-black/80 backdrop-blur-xl border-t md:border-b md:border-t-0 border-white/10 px-4 pt-3 pb-[calc(1.5rem+var(--safe-area-inset-bottom))] md:py-3 shadow-2xl"
+      >
         <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center gap-3 md:gap-0">
           <div className="flex w-full md:w-auto justify-between items-center">
             <div className="flex items-center gap-2 group cursor-pointer">
               <Layers className="text-indigo-500 group-hover:animate-spin" />
-              <span className="font-bold tracking-tighter text-xl glitch-hover">GLITCH<span className="font-light text-white/50">WORKS</span></span>
+              <span className="font-bold tracking-tighter text-xl glitch-hover">
+                GLITCH<span className="font-light text-white/50">WORKS</span>
+              </span>
             </div>
-            <button type="button" data-testid="aether-settings-open" onClick={() => setShowSettings(true)} className="md:hidden text-white/50 hover:text-indigo-400 p-2">
+            <button
+              type="button"
+              data-testid="aether-settings-open"
+              onClick={() => setShowSettings(true)}
+              className="md:hidden text-white/50 hover:text-indigo-400 p-2"
+            >
               <Settings size={20} />
             </button>
           </div>
-          
+
           <div className="flex w-full md:w-auto items-center justify-between md:justify-end gap-2">
             {/* Scroll mask for mobile */}
             <div className="flex gap-2 bg-slate-900/50 p-1.5 rounded-full overflow-x-auto hide-scrollbar flex-nowrap w-full md:w-auto [mask-image:linear-gradient(to_right,black_85%,transparent_100%)] md:[mask-image:none]">
@@ -368,34 +648,46 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
                 { id: 'dex', icon: LayoutGrid, color: 'indigo' },
                 { id: 'arena', icon: Sword, color: 'red' },
                 { id: 'oracle', icon: Sparkles, color: 'purple' },
-                { id: 'forge', icon: Hammer, color: 'emerald' }
-              ].map(btn => (
-                <button 
+                { id: 'forge', icon: Hammer, color: 'emerald' },
+              ].map((btn) => (
+                <button
                   type="button"
                   data-testid={`aether-nav-${btn.id}`}
                   key={btn.id}
-                  onClick={() => setView(btn.id)} 
+                  onClick={() => setView(btn.id)}
                   className={`shrink-0 px-4 md:px-5 py-2.5 rounded-full text-xs font-mono uppercase tracking-widest transition-all flex items-center gap-2 border ${
-                    view === btn.id 
-                      ? `bg-${btn.color}-600/20 border-${btn.color}-500/50 text-${btn.color}-300 shadow-[0_0_15px_rgba(var(--tw-colors-${btn.color}-500),0.3)]` 
+                    view === btn.id
+                      ? `bg-${btn.color}-600/20 border-${btn.color}-500/50 text-${btn.color}-300 shadow-[0_0_15px_rgba(var(--tw-colors-${btn.color}-500),0.3)]`
                       : 'border-transparent text-white/40 hover:text-white hover:bg-white/5'
                   }`}
                 >
-                  <btn.icon size={14} className={view === btn.id ? 'animate-pulse' : ''} /> 
+                  <btn.icon
+                    size={14}
+                    className={view === btn.id ? 'animate-pulse' : ''}
+                  />
                   <span>{btn.id}</span>
                 </button>
               ))}
-              <div className="w-8 shrink-0 md:hidden" /> {/* Spacer to allow full scroll visibility */}
+              <div className="w-8 shrink-0 md:hidden" />{' '}
+              {/* Spacer to allow full scroll visibility */}
             </div>
-            
-            <button type="button" data-testid="aether-settings-open-desktop" onClick={() => setShowSettings(true)} className="hidden md:flex text-white/40 hover:text-indigo-400 p-2 ml-2 bg-slate-900/50 rounded-full border border-transparent hover:border-white/10 transition-colors">
+
+            <button
+              type="button"
+              data-testid="aether-settings-open-desktop"
+              onClick={() => setShowSettings(true)}
+              className="hidden md:flex text-white/40 hover:text-indigo-400 p-2 ml-2 bg-slate-900/50 rounded-full border border-transparent hover:border-white/10 transition-colors"
+            >
               <Settings size={18} />
             </button>
           </div>
         </div>
       </nav>
 
-      <main data-testid="aether-main" className="relative z-10 pt-4 md:pt-28 pb-32 md:pb-12 max-w-6xl mx-auto min-h-screen">
+      <main
+        data-testid="aether-main"
+        className="relative z-10 pt-4 md:pt-28 pb-32 md:pb-12 max-w-6xl mx-auto min-h-screen"
+      >
         {view === 'dex' && renderDexView()}
         {view === 'arena' && renderArenaView()}
         {view === 'oracle' && renderOracleView()}
@@ -404,9 +696,21 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
 
       {/* Card Details Modal */}
       {selectedCard && view === 'dex' && (
-        <div data-testid="aether-modal-card" className="fixed inset-0 z-[900] flex items-center justify-center bg-black/90 backdrop-blur-md p-4 animate-in fade-in duration-200" onClick={() => setSelectedCard(null)}>
-          <div className="relative transform transition-transform animate-in zoom-in-95 duration-300" onClick={e => e.stopPropagation()}>
-            <button type="button" data-testid="aether-modal-card-close" className="absolute -top-16 right-0 text-white/50 hover:text-white transition-colors bg-white/5 p-2 rounded-full border border-white/10" onClick={() => setSelectedCard(null)}>
+        <div
+          data-testid="aether-modal-card"
+          className="fixed inset-0 z-[900] flex items-center justify-center bg-black/90 backdrop-blur-md p-4 animate-in fade-in duration-200"
+          onClick={() => setSelectedCard(null)}
+        >
+          <div
+            className="relative transform transition-transform animate-in zoom-in-95 duration-300"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              data-testid="aether-modal-card-close"
+              className="absolute -top-16 right-0 text-white/50 hover:text-white transition-colors bg-white/5 p-2 rounded-full border border-white/10"
+              onClick={() => setSelectedCard(null)}
+            >
               <X size={24} />
             </button>
             <Card data={selectedCard} isFlipped={true} size="lg" />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -146,8 +146,8 @@ describe('App', () => {
   });
 
   it('usePersistedDeck logs telemetry warning when storage.save reports quota failure', async () => {
-    const { createMemoryDeckStorage } = await import('./adapters/memoryDeckStorage.js');
-    const { createConsoleTelemetry } = await import('./adapters/consoleTelemetry.js');
+    const { createMemoryDeckStorage } =
+      await import('./adapters/memoryDeckStorage.js');
 
     const storage = createMemoryDeckStorage();
     const alwaysFailSave = {
@@ -164,6 +164,29 @@ describe('App', () => {
       'warn',
       'DECK_SAVE_QUOTA_EXCEEDED',
       expect.objectContaining({ error: expect.stringContaining('QuotaExceededError') })
+    );
+  });
+
+  it('Arena Mode Selector updates UI and disables combat when Combat Disabled is selected', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByTestId('aether-nav-arena'));
+
+    expect(screen.getByTestId('aether-arena-mode-select')).toBeInTheDocument();
+    expect(screen.getByTestId('aether-arena-log')).toHaveTextContent(
+      'WAITING FOR DATA INPUT',
+    );
+
+    // Select 'Combat Disabled' mode
+    const select = screen.getByTestId('aether-arena-mode-select');
+    await user.selectOptions(select, 'combatDisabled');
+
+    expect(screen.getByTestId('aether-arena-log')).toHaveTextContent(
+      'SYSTEMS IN HARMONY. NO CLASH POSSIBLE.',
+    );
+    expect(screen.getByTestId('aether-arena-clash')).toBeDisabled();
+    expect(screen.getByTestId('aether-arena-clash')).toHaveTextContent(
+      'COMBAT DISABLED',
     );
   });
 });

--- a/src/domain/battle.js
+++ b/src/domain/battle.js
@@ -1,41 +1,5 @@
-import { ELEMENTAL_ADVANTAGE } from './elemental.js';
+import { resolveBattleWithEngine } from "./battleEngine.js";
 
 export function resolveBattle(p1, p2) {
-  if (!p1 || !p2) {
-    return {
-      winner: null,
-      logLine: '[ ERR: INCOMPLETE DATA ]',
-      p1Advantage: 1.0,
-      p2Advantage: 1.0,
-    };
-  }
-
-  const p1Advantage = ELEMENTAL_ADVANTAGE[p1.type]?.[p2.type] || 1.0;
-  const p2Advantage = ELEMENTAL_ADVANTAGE[p2.type]?.[p1.type] || 1.0;
-
-  const p1Score = (p1.stats.atk + p1.stats.spd) * p1Advantage;
-  const p2Score = (p2.stats.atk + p2.stats.spd) * p2Advantage;
-
-  if (p1Score > p2Score) {
-    return {
-      winner: 'p1',
-      logLine: `> ${p1.name.toUpperCase()} OVERWRITES ${p2.name.toUpperCase()}${p1Advantage > 1.0 ? " (TYPE_ADVANTAGE)" : ""}`,
-      p1Advantage,
-      p2Advantage,
-    };
-  } else if (p2Score > p1Score) {
-    return {
-      winner: 'p2',
-      logLine: `> ${p2.name.toUpperCase()} OVERWRITES ${p1.name.toUpperCase()}${p2Advantage > 1.0 ? " (TYPE_ADVANTAGE)" : ""}`,
-      p1Advantage,
-      p2Advantage,
-    };
-  } else {
-    return {
-      winner: null,
-      logLine: "> EQUILIBRIUM ACHIEVED. NO DELETION.",
-      p1Advantage,
-      p2Advantage,
-    };
-  }
+  return resolveBattleWithEngine(p1, p2, "standard");
 }

--- a/src/domain/battleEngine.js
+++ b/src/domain/battleEngine.js
@@ -1,0 +1,130 @@
+import { ELEMENTAL_ADVANTAGE } from './elemental.js';
+
+export const baseScoreComponent = {
+  id: 'baseScore',
+  calculate: (card) => card.stats.atk + card.stats.spd
+};
+
+export const elementalComponent = {
+  id: 'elemental',
+  calculate: (card, opponent, advantages = ELEMENTAL_ADVANTAGE) => {
+    return advantages[card.type]?.[opponent.type] || 1.0;
+  }
+};
+
+export const arenaModes = {
+  standard: {
+    id: 'standard',
+    name: 'Standard Clash',
+    description: 'Standard rules: (ATK + SPD) * Elemental Advantage',
+    modifiers: []
+  },
+  speedBlitz: {
+    id: 'speedBlitz',
+    name: 'Speed Blitz',
+    description: 'Speed is doubled: (ATK + SPD * 2) * Elemental Advantage',
+    modifiers: [
+      {
+        id: 'speedMultiplier',
+        applyBase: (card) => card.stats.atk + (card.stats.spd * 2)
+      }
+    ]
+  },
+  suddenDeath: {
+    id: 'suddenDeath',
+    name: 'Sudden Death',
+    description: 'Pure power clash: (ATK * 3) with no elemental advantages',
+    modifiers: [
+      {
+        id: 'atkOnlyMultiplier',
+        applyBase: (card) => card.stats.atk * 3
+      },
+      {
+        id: 'ignoreElemental',
+        applyElemental: () => 1.0
+      }
+    ]
+  },
+  combatDisabled: {
+    id: 'combatDisabled',
+    name: 'Combat Disabled (Pure Tarot)',
+    description: 'Combat mechanics are disabled. Ideal for peaceful tarot pulls.',
+    modifiers: [
+      {
+        id: 'zeroCombat',
+        applyBase: () => 0,
+        applyElemental: () => 1.0
+      }
+    ]
+  }
+};
+
+export function resolveBattleWithEngine(p1, p2, modeId = 'standard') {
+  if (!p1 || !p2) {
+    return {
+      winner: null,
+      logLine: '[ ERR: INCOMPLETE DATA ]',
+      p1Advantage: 1.0,
+      p2Advantage: 1.0,
+      p1Score: 0,
+      p2Score: 0,
+    };
+  }
+
+  const mode = arenaModes[modeId] || arenaModes.standard;
+
+  // 1. Resolve Base Score
+  const baseModifier = mode.modifiers.find(m => m.applyBase);
+  const p1Base = baseModifier ? baseModifier.applyBase(p1) : baseScoreComponent.calculate(p1);
+  const p2Base = baseModifier ? baseModifier.applyBase(p2) : baseScoreComponent.calculate(p2);
+
+  // 2. Resolve Elemental Multiplier
+  const elementalModifier = mode.modifiers.find(m => m.applyElemental);
+  const p1Adv = elementalModifier ? elementalModifier.applyElemental(p1, p2) : elementalComponent.calculate(p1, p2);
+  const p2Adv = elementalModifier ? elementalModifier.applyElemental(p2, p1) : elementalComponent.calculate(p2, p1);
+
+  // 3. Aggregate Scores
+  const p1Score = p1Base * p1Adv;
+  const p2Score = p2Base * p2Adv;
+
+  if (modeId === 'combatDisabled') {
+    return {
+      winner: null,
+      logLine: '> SYSTEMS IN HARMONY. NO CLASH POSSIBLE.',
+      p1Advantage: 1.0,
+      p2Advantage: 1.0,
+      p1Score: 0,
+      p2Score: 0
+    };
+  }
+
+  // 4. Determine Winner
+  if (p1Score > p2Score) {
+    return {
+      winner: 'p1',
+      logLine: `> ${p1.name.toUpperCase()} OVERWRITES ${p2.name.toUpperCase()}${p1Adv > 1.0 ? " (TYPE_ADVANTAGE)" : ""}`,
+      p1Advantage: p1Adv,
+      p2Advantage: p2Adv,
+      p1Score,
+      p2Score
+    };
+  } else if (p2Score > p1Score) {
+    return {
+      winner: 'p2',
+      logLine: `> ${p2.name.toUpperCase()} OVERWRITES ${p1.name.toUpperCase()}${p2Adv > 1.0 ? " (TYPE_ADVANTAGE)" : ""}`,
+      p1Advantage: p1Adv,
+      p2Advantage: p2Adv,
+      p1Score,
+      p2Score
+    };
+  } else {
+    return {
+      winner: null,
+      logLine: "> EQUILIBRIUM ACHIEVED. NO DELETION.",
+      p1Advantage: p1Adv,
+      p2Advantage: p2Adv,
+      p1Score,
+      p2Score
+    };
+  }
+}

--- a/src/domain/battleEngine.test.js
+++ b/src/domain/battleEngine.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  baseScoreComponent,
+  elementalComponent,
+  resolveBattleWithEngine
+} from './battleEngine.js';
+
+describe('battleEngine', () => {
+  const p1 = {
+    name: 'Alpha',
+    type: 'fire',
+    stats: { atk: 50, def: 30, spd: 20 },
+  };
+
+  const p2 = {
+    name: 'Omega',
+    type: 'wind',
+    stats: { atk: 40, def: 40, spd: 30 },
+  };
+
+  describe('baseScoreComponent', () => {
+    it('calculates score as ATK + SPD', () => {
+      expect(baseScoreComponent.calculate(p1)).toBe(70);
+      expect(baseScoreComponent.calculate(p2)).toBe(70);
+    });
+  });
+
+  describe('elementalComponent', () => {
+    it('returns correct elemental multiplier', () => {
+      // Fire has advantage over wind (1.5x)
+      expect(elementalComponent.calculate(p1, p2)).toBe(1.5);
+      // Wind has no advantage over fire (1.0x)
+      expect(elementalComponent.calculate(p2, p1)).toBe(1.0);
+    });
+  });
+
+  describe('resolveBattleWithEngine', () => {
+    it('handles incomplete data gracefully', () => {
+      const result = resolveBattleWithEngine(p1, null);
+      expect(result.winner).toBeNull();
+      expect(result.logLine).toBe('[ ERR: INCOMPLETE DATA ]');
+    });
+
+    it('resolves standard mode correctly', () => {
+      // p1 score: (50 + 20) * 1.5 = 105
+      // p2 score: (40 + 30) * 1.0 = 70
+      const result = resolveBattleWithEngine(p1, p2, 'standard');
+      expect(result.winner).toBe('p1');
+      expect(result.p1Score).toBe(105);
+      expect(result.p2Score).toBe(70);
+      expect(result.p1Advantage).toBe(1.5);
+      expect(result.p2Advantage).toBe(1.0);
+      expect(result.logLine).toContain('ALPHA OVERWRITES OMEGA');
+    });
+
+    it('resolves speedBlitz mode correctly (doubles speed)', () => {
+      // p1 score: (50 + 20 * 2) * 1.5 = 90 * 1.5 = 135
+      // p2 score: (40 + 30 * 2) * 1.0 = 100 * 1.0 = 100
+      const result = resolveBattleWithEngine(p1, p2, 'speedBlitz');
+      expect(result.winner).toBe('p1');
+      expect(result.p1Score).toBe(135);
+      expect(result.p2Score).toBe(100);
+    });
+
+    it('resolves suddenDeath mode correctly (triples ATK, ignores elemental)', () => {
+      // p1 score: (50 * 3) * 1.0 = 150
+      // p2 score: (40 * 3) * 1.0 = 120
+      const result = resolveBattleWithEngine(p1, p2, 'suddenDeath');
+      expect(result.winner).toBe('p1');
+      expect(result.p1Score).toBe(150);
+      expect(result.p2Score).toBe(120);
+      expect(result.p1Advantage).toBe(1.0);
+      expect(result.p2Advantage).toBe(1.0);
+    });
+
+    it('resolves combatDisabled mode correctly (peaceful harmony)', () => {
+      const result = resolveBattleWithEngine(p1, p2, 'combatDisabled');
+      expect(result.winner).toBeNull();
+      expect(result.p1Score).toBe(0);
+      expect(result.p2Score).toBe(0);
+      expect(result.logLine).toBe('> SYSTEMS IN HARMONY. NO CLASH POSSIBLE.');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Refactored monolithic `resolveBattle` from `src/domain/battle.js` into a modular, component-based `battleEngine.js` following GW-AAP.
- Added base score, elemental advantage, and custom arena mode modifiers (Standard, Speed Blitz, Sudden Death, Combat Disabled).
- Integrated an Arena Mode selector dropdown into the Arena UI, allowing the user to select the active ruleset.
- Implemented peaceful "Combat Disabled" mode which blocks clashing and displays a harmonious status log.

## Test plan
- Added comprehensive unit tests in `src/domain/battleEngine.test.js` covering every component, modifier, and mode.
- Added UI integration test in `src/App.test.jsx` verifying selector behavior and combat lockout.
- Verified that all 35 tests pass cleanly and ESLint reports zero errors.