### PR TITLE
feat(cosmetics): custom card cosmetics, oracle layouts, and TCG mechanics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
 
   // Settings / Aesthetics State
   const [showSettings, setShowSettings] = useState(false);
+  const [deckBack, setDeckBack] = useState('standard');
   const [aesthetics, setAesthetics] = useState({
     glitch: 50,
     crt: 40,
@@ -40,6 +41,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
 
   // Oracle State
   const [spread, setSpread] = useState([]);
+  const [oracleLayout, setOracleLayout] = useState('threeCard');
 
   // Forge State
   const [forgeData, setForgeData] = useState({
@@ -53,7 +55,11 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
     icon: 'Sparkles',
     customImage: null,
     hideStats: false,
-    hideDesc: false
+    hideDesc: false,
+    frame: 'standard',
+    hat: 'none',
+    rarity: 'common',
+    ability: 'none'
   });
 
   // Sync CSS variables for Glitchworks aesthetic
@@ -125,7 +131,8 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
   };
 
   const handleDrawSpread = () => {
-    setSpread(drawSpread(deck));
+    const cardCount = oracleLayout === 'celticCross' ? 5 : 3;
+    setSpread(drawSpread(deck, cardCount));
   };
 
   const handleImageUpload = (e) => {
@@ -150,7 +157,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
     <div data-testid="aether-view-dex" className="p-4 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6 pb-24">
       {deck.map(card => (
         <div key={card.id} className="flex justify-center transform hover:-translate-y-2 transition-transform duration-300">
-          <Card data={card} isFlipped={true} onClick={() => setSelectedCard(card)} />
+          <Card data={card} isFlipped={true} onClick={() => setSelectedCard(card)} deckBack={deckBack} />
         </div>
       ))}
     </div>
@@ -173,6 +180,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
               isFlipped={true}
               clashing={isClashing}
               onClick={() => setArenaSlots({ ...arenaSlots, p1: null })}
+              deckBack={deckBack}
             />
           ) : (
             <div className="w-64 h-[28rem] rounded-xl border-2 border-dashed border-indigo-500/20 bg-indigo-900/10 flex items-center justify-center text-indigo-400/30 font-mono text-sm">
@@ -276,6 +284,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
               isFlipped={true}
               clashing={isClashing}
               onClick={() => setArenaSlots({ ...arenaSlots, p2: null })}
+              deckBack={deckBack}
             />
           ) : (
             <div className="w-64 h-[28rem] rounded-xl border-2 border-dashed border-red-500/20 bg-red-900/10 flex items-center justify-center text-red-400/30 font-mono text-sm">
@@ -301,6 +310,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
                 isFlipped={true}
                 onClick={() => handleArenaSelect(card)}
                 size="sm"
+                deckBack={deckBack}
               />
             </div>
           ))}
@@ -311,28 +321,127 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
   );
 
   const renderOracleView = () => (
-    <div data-testid="aether-view-oracle" className="flex flex-col items-center justify-center min-h-[80vh] gap-12 p-4">
+    <div data-testid="aether-view-oracle" className="flex flex-col items-center justify-center min-h-[80vh] gap-8 p-4">
       <div className="text-center space-y-2">
         <h2 className="text-3xl font-light text-indigo-300 glitch-text tracking-widest">THE ORACLE</h2>
         <p className="text-white/40 font-mono text-xs max-w-md mx-auto">Accessing probabilistic timelines...</p>
       </div>
 
-      <div className="flex flex-col md:flex-row gap-8 lg:gap-12 perspective-1000">
+      {/* Oracle Layout Selector */}
+      <div className="w-full max-w-[240px] flex flex-col gap-1.5">
+        <label className="text-[10px] font-mono text-indigo-400/70 uppercase tracking-widest text-center">
+          Spread Layout
+        </label>
+        <select
+          data-testid="aether-oracle-layout-select"
+          value={oracleLayout}
+          onChange={(e) => {
+            setOracleLayout(e.target.value);
+            setSpread([]);
+          }}
+          className="w-full bg-slate-900/80 border border-white/10 rounded px-3 py-2 text-white font-mono text-xs focus:outline-none focus:border-indigo-500 text-center appearance-none cursor-pointer"
+        >
+          <option value="threeCard">PAST / PRESENT / FUTURE (3 CARDS)</option>
+          <option value="celticCross">CELTIC CROSS (5 CARDS)</option>
+          <option value="theClash">THE CLASH (3 CARDS)</option>
+        </select>
+      </div>
+
+      {/* Dynamic Layout Rendering */}
+      <div className="my-4">
         {spread.length > 0 ? (
-          spread.map((card, index) => (
-            <div key={card.id} className="flex flex-col items-center gap-4 animate-in fade-in slide-in-from-bottom-10 duration-700" style={{animationDelay: `${index * 200}ms`}}>
-              <span className="text-[10px] font-mono text-white/40 tracking-widest uppercase border border-white/10 bg-black/50 px-3 py-1 rounded-full">
-                {index === 0 ? 'T-Minus (Past)' : index === 1 ? 'T-Zero (Present)' : 'T-Plus (Future)'}
-              </span>
-              <Card data={card} isFlipped={true} />
+          // Render Active Spread
+          oracleLayout === 'threeCard' ? (
+            <div className="flex flex-col md:flex-row gap-8 lg:gap-12 perspective-1000">
+              {spread.map((card, index) => (
+                <div key={card.id} className="flex flex-col items-center gap-4 animate-in fade-in slide-in-from-bottom-10 duration-700" style={{animationDelay: `${index * 200}ms`}}>
+                  <span className="text-[10px] font-mono text-white/40 tracking-widest uppercase border border-white/10 bg-black/50 px-3 py-1 rounded-full">
+                    {index === 0 ? 'T-Minus (Past)' : index === 1 ? 'T-Zero (Present)' : 'T-Plus (Future)'}
+                  </span>
+                  <Card data={card} isFlipped={true} deckBack={deckBack} />
+                </div>
+              ))}
             </div>
-          ))
+          ) : oracleLayout === 'celticCross' ? (
+            <div className="flex flex-col md:grid md:grid-cols-3 gap-8 items-center justify-items-center max-w-4xl">
+              {/* Row 1: Goal */}
+              <div></div>
+              <div className="flex flex-col items-center gap-2 animate-in fade-in slide-in-from-bottom-10 duration-700" style={{animationDelay: '400ms'}}>
+                <span className="text-[10px] font-mono text-white/40 tracking-widest uppercase border border-white/10 bg-black/50 px-3 py-1 rounded-full">Goal</span>
+                <Card data={spread[2]} isFlipped={true} deckBack={deckBack} size="sm" />
+              </div>
+              <div></div>
+
+              {/* Row 2: Past, Present/Obstacle, Future */}
+              <div className="flex flex-col items-center gap-2 animate-in fade-in slide-in-from-bottom-10 duration-700" style={{animationDelay: '600ms'}}>
+                <span className="text-[10px] font-mono text-white/40 tracking-widest uppercase border border-white/10 bg-black/50 px-3 py-1 rounded-full">Past</span>
+                <Card data={spread[3]} isFlipped={true} deckBack={deckBack} size="sm" />
+              </div>
+              <div className="relative w-24 h-40 flex items-center justify-center animate-in fade-in duration-700">
+                <div className="absolute z-10">
+                  <Card data={spread[0]} isFlipped={true} deckBack={deckBack} size="sm" />
+                </div>
+                <div className="absolute z-20 rotate-90 opacity-90 scale-95">
+                  <Card data={spread[1]} isFlipped={true} deckBack={deckBack} size="sm" />
+                </div>
+              </div>
+              <div className="flex flex-col items-center gap-2 animate-in fade-in slide-in-from-bottom-10 duration-700" style={{animationDelay: '800ms'}}>
+                <span className="text-[10px] font-mono text-white/40 tracking-widest uppercase border border-white/10 bg-black/50 px-3 py-1 rounded-full">Future</span>
+                <Card data={spread[4]} isFlipped={true} deckBack={deckBack} size="sm" />
+              </div>
+
+              {/* Row 3: Label */}
+              <div></div>
+              <div className="text-center text-[9px] font-mono text-indigo-400/60 uppercase tracking-widest animate-in fade-in duration-1000">
+                Present (Under) / Obstacle (Cross)
+              </div>
+              <div></div>
+            </div>
+          ) : (
+            // theClash Layout
+            <div className="flex flex-col gap-8 items-center">
+              <div className="flex flex-col md:flex-row gap-8 lg:gap-16">
+                <div className="flex flex-col items-center gap-4 animate-in fade-in slide-in-from-bottom-10 duration-700">
+                  <span className="text-[10px] font-mono text-indigo-400 tracking-widest uppercase border border-indigo-500/20 bg-black/50 px-3 py-1 rounded-full">Alpha (Thesis)</span>
+                  <Card data={spread[0]} isFlipped={true} deckBack={deckBack} />
+                </div>
+                <div className="flex flex-col items-center gap-4 animate-in fade-in slide-in-from-bottom-10 duration-700" style={{animationDelay: '200ms'}}>
+                  <span className="text-[10px] font-mono text-red-400 tracking-widest uppercase border border-red-500/20 bg-black/50 px-3 py-1 rounded-full">Omega (Antithesis)</span>
+                  <Card data={spread[1]} isFlipped={true} deckBack={deckBack} />
+                </div>
+              </div>
+              <div className="flex flex-col items-center gap-4 animate-in fade-in slide-in-from-bottom-10 duration-1000" style={{animationDelay: '500ms'}}>
+                <span className="text-[10px] font-mono text-purple-400 tracking-widest uppercase border border-purple-500/20 bg-black/50 px-3 py-1 rounded-full">Synthesis (Outcome)</span>
+                <Card data={spread[2]} isFlipped={true} deckBack={deckBack} />
+              </div>
+            </div>
+          )
         ) : (
-          <div className="flex gap-8 lg:gap-12 opacity-30">
-             <div className="w-64 h-[28rem] rounded-xl bg-slate-800/50 border border-white/10 border-dashed"></div>
-             <div className="w-64 h-[28rem] rounded-xl bg-slate-800/50 border border-white/10 border-dashed hidden md:block"></div>
-             <div className="w-64 h-[28rem] rounded-xl bg-slate-800/50 border border-white/10 border-dashed hidden md:block"></div>
-          </div>
+          // Render Placeholders
+          oracleLayout === 'celticCross' ? (
+            <div className="grid grid-cols-3 gap-8 items-center justify-items-center opacity-30 max-w-4xl">
+              <div></div>
+              <div className="w-24 h-40 rounded-xl bg-slate-800/50 border border-white/10 border-dashed"></div>
+              <div></div>
+              <div className="w-24 h-40 rounded-xl bg-slate-800/50 border border-white/10 border-dashed"></div>
+              <div className="w-24 h-40 rounded-xl bg-slate-800/50 border border-white/10 border-dashed"></div>
+              <div className="w-24 h-40 rounded-xl bg-slate-800/50 border border-white/10 border-dashed"></div>
+            </div>
+          ) : oracleLayout === 'theClash' ? (
+            <div className="flex flex-col gap-8 items-center opacity-30">
+              <div className="flex flex-col md:flex-row gap-8 lg:gap-16">
+                <div className="w-64 h-[28rem] rounded-xl bg-slate-800/50 border border-white/10 border-dashed"></div>
+                <div className="w-64 h-[28rem] rounded-xl bg-slate-800/50 border border-white/10 border-dashed"></div>
+              </div>
+              <div className="w-64 h-[28rem] rounded-xl bg-slate-800/50 border border-white/10 border-dashed"></div>
+            </div>
+          ) : (
+            <div className="flex gap-8 lg:gap-12 opacity-30">
+              <div className="w-64 h-[28rem] rounded-xl bg-slate-800/50 border border-white/10 border-dashed"></div>
+              <div className="w-64 h-[28rem] rounded-xl bg-slate-800/50 border border-white/10 border-dashed hidden md:block"></div>
+              <div className="w-64 h-[28rem] rounded-xl bg-slate-800/50 border border-white/10 border-dashed hidden md:block"></div>
+            </div>
+          )
         )}
       </div>
 
@@ -353,7 +462,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
           <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse" />
           Live Preview
         </div>
-        <Card data={forgeData} isFlipped={true} />
+        <Card data={forgeData} isFlipped={true} deckBack={deckBack} />
         <button
           type="button"
           data-testid="aether-forge-compile"
@@ -450,6 +559,84 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
                   {k.toUpperCase()}
                 </option>
               ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">
+              Card Frame
+            </label>
+            <select
+              data-testid="aether-forge-frame"
+              value={forgeData.frame || 'standard'}
+              onChange={(e) =>
+                setForgeData({ ...forgeData, frame: e.target.value })
+              }
+              className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-mono text-xs focus:outline-none focus:border-emerald-500 appearance-none"
+            >
+              <option value="standard">STANDARD</option>
+              <option value="neonGlow">NEON GLOW</option>
+              <option value="goldFoil">GOLD FOIL</option>
+              <option value="glitchMatrix">GLITCH MATRIX</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">
+              Accessory / Hat
+            </label>
+            <select
+              data-testid="aether-forge-hat"
+              value={forgeData.hat || 'none'}
+              onChange={(e) =>
+                setForgeData({ ...forgeData, hat: e.target.value })
+              }
+              className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-mono text-xs focus:outline-none focus:border-emerald-500 appearance-none"
+            >
+              <option value="none">NONE</option>
+              <option value="cyberCrown">CYBER CROWN</option>
+              <option value="glitchHalo">GLITCH HALO</option>
+              <option value="retroVisor">RETRO VISOR</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">
+              Card Rarity
+            </label>
+            <select
+              data-testid="aether-forge-rarity"
+              value={forgeData.rarity || 'common'}
+              onChange={(e) =>
+                setForgeData({ ...forgeData, rarity: e.target.value })
+              }
+              className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-mono text-xs focus:outline-none focus:border-emerald-500 appearance-none"
+            >
+              <option value="common">COMMON</option>
+              <option value="rare">RARE</option>
+              <option value="ultra-rare">ULTRA-RARE</option>
+              <option value="glitched">GLITCHED</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-[10px] font-mono text-emerald-500/70 mb-2 uppercase tracking-widest">
+              Active Ability
+            </label>
+            <select
+              data-testid="aether-forge-ability"
+              value={forgeData.ability || 'none'}
+              onChange={(e) =>
+                setForgeData({ ...forgeData, ability: e.target.value })
+              }
+              className="w-full bg-slate-900/50 border border-white/10 rounded px-3 py-3 text-white font-mono text-xs focus:outline-none focus:border-emerald-500 appearance-none"
+            >
+              <option value="none">NONE</option>
+              <option value="overdrive">OVERDRIVE</option>
+              <option value="ironWall">IRON WALL</option>
+              <option value="voidShield">VOID SHIELD</option>
             </select>
           </div>
         </div>
@@ -613,6 +800,24 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
                 color="red"
                 onChange={(v) => setAesthetics((s) => ({ ...s, noise: v }))}
               />
+
+              {/* Deck Back Selector */}
+              <div className="flex flex-col gap-1.5 border-t border-white/10 pt-4">
+                <label className="text-[10px] font-mono text-indigo-400/70 uppercase tracking-widest text-center">
+                  Active Deck Back
+                </label>
+                <select
+                  data-testid="aether-settings-deckback"
+                  value={deckBack}
+                  onChange={(e) => setDeckBack(e.target.value)}
+                  className="w-full bg-slate-950 border border-white/10 rounded px-3 py-2 text-white font-mono text-xs focus:outline-none focus:border-indigo-500 text-center appearance-none cursor-pointer"
+                >
+                  <option value="standard">STANDARD</option>
+                  <option value="cyberpunkGrid">CYBERPUNK GRID</option>
+                  <option value="voidVortex">VOID VORTEX</option>
+                  <option value="goldenAether">GOLDEN AETHER</option>
+                </select>
+              </div>
             </div>
           </div>
         </div>
@@ -713,7 +918,7 @@ export default function App({ storage = defaultStorage, telemetry = defaultTelem
             >
               <X size={24} />
             </button>
-            <Card data={selectedCard} isFlipped={true} size="lg" />
+            <Card data={selectedCard} isFlipped={true} size="lg" deckBack={deckBack} />
           </div>
         </div>
       )}

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -189,4 +189,83 @@ describe('App', () => {
       'COMBAT DISABLED',
     );
   });
+
+  it('allows selecting a custom deck back in the Settings modal', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // Open settings modal
+    await user.click(screen.getByTestId('aether-settings-open-desktop'));
+    expect(screen.getByTestId('aether-modal-settings')).toBeInTheDocument();
+
+    // Select 'Cyberpunk Grid' deck back
+    const select = screen.getByTestId('aether-settings-deckback');
+    expect(select).toBeInTheDocument();
+    expect(select.value).toBe('standard');
+
+    await user.selectOptions(select, 'cyberpunkGrid');
+    expect(select.value).toBe('cyberpunkGrid');
+  });
+
+  it('allows customizing frame, hat, rarity, and ability in the Forge view', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByTestId('aether-nav-forge'));
+
+    // Check selectors exist
+    const frameSelect = screen.getByTestId('aether-forge-frame');
+    const hatSelect = screen.getByTestId('aether-forge-hat');
+    const raritySelect = screen.getByTestId('aether-forge-rarity');
+    const abilitySelect = screen.getByTestId('aether-forge-ability');
+
+    expect(frameSelect).toBeInTheDocument();
+    expect(hatSelect).toBeInTheDocument();
+    expect(raritySelect).toBeInTheDocument();
+    expect(abilitySelect).toBeInTheDocument();
+
+    // Select custom properties
+    await user.selectOptions(frameSelect, 'glitchMatrix');
+    await user.selectOptions(hatSelect, 'cyberCrown');
+    await user.selectOptions(raritySelect, 'glitched');
+    await user.selectOptions(abilitySelect, 'voidShield');
+
+    expect(frameSelect.value).toBe('glitchMatrix');
+    expect(hatSelect.value).toBe('cyberCrown');
+    expect(raritySelect.value).toBe('glitched');
+    expect(abilitySelect.value).toBe('voidShield');
+  });
+
+  it('allows changing Oracle layouts and drawing different card counts', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByTestId('aether-nav-oracle'));
+
+    const layoutSelect = screen.getByTestId('aether-oracle-layout-select');
+    expect(layoutSelect).toBeInTheDocument();
+    expect(layoutSelect.value).toBe('threeCard');
+
+    // Draw standard 3 card spread
+    await user.click(screen.getByTestId('aether-oracle-draw'));
+    expect(screen.getByText('T-Minus (Past)')).toBeInTheDocument();
+
+    // Change to Celtic Cross (clears spread)
+    await user.selectOptions(layoutSelect, 'celticCross');
+    expect(screen.queryByText('T-Minus (Past)')).not.toBeInTheDocument();
+
+    // Draw Celtic Cross (5 cards)
+    await user.click(screen.getByTestId('aether-oracle-draw'));
+    expect(screen.getByText('Goal')).toBeInTheDocument();
+    expect(screen.getByText('Past')).toBeInTheDocument();
+    expect(screen.getByText('Future')).toBeInTheDocument();
+
+    // Change to The Clash
+    await user.selectOptions(layoutSelect, 'theClash');
+    expect(screen.queryByText('Goal')).not.toBeInTheDocument();
+
+    // Draw The Clash (3 cards)
+    await user.click(screen.getByTestId('aether-oracle-draw'));
+    expect(screen.getByText('Alpha (Thesis)')).toBeInTheDocument();
+    expect(screen.getByText('Omega (Antithesis)')).toBeInTheDocument();
+    expect(screen.getByText('Synthesis (Outcome)')).toBeInTheDocument();
+  });
 });

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Sword, Shield, Wind, Sparkles, RotateCcw, Flame, Droplets, Zap, Skull, Eye, Star, Hammer
+  Sword, Shield, Wind, Sparkles, RotateCcw, Flame, Droplets, Zap, Skull, Eye, Star, Hammer, Crown
 } from 'lucide-react';
 import { getTypeColor } from '../domain/elemental.js';
 
@@ -11,7 +11,68 @@ const iconMap = {
   Shield: <Shield size={64} />, Hammer: <Hammer size={64} />,
 };
 
-export const Card = ({ data, isFlipped, onClick, size = 'md', showStats = true, clashing = false }) => {
+const glowColors = {
+  fire: 'shadow-[0_0_20px_rgba(239,68,68,0.6)] border-red-500',
+  water: 'shadow-[0_0_20px_rgba(59,130,246,0.6)] border-blue-500',
+  electric: 'shadow-[0_0_20px_rgba(234,179,8,0.6)] border-yellow-500',
+  wind: 'shadow-[0_0_20px_rgba(16,185,129,0.6)] border-emerald-500',
+  void: 'shadow-[0_0_20px_rgba(99,102,241,0.6)] border-indigo-500',
+  dark: 'shadow-[0_0_20px_rgba(100,116,139,0.6)] border-slate-500',
+};
+
+const renderDeckBack = (deckBack) => {
+  switch (deckBack) {
+    case 'cyberpunkGrid':
+      return (
+        <div className="absolute inset-0 backface-hidden w-full h-full rounded-xl bg-slate-950 border-2 border-pink-500/50 flex items-center justify-center overflow-hidden shadow-xl hover:border-cyan-400 transition-colors">
+          <div className="absolute inset-0 opacity-30 bg-[linear-gradient(to_right,#ec4899_1px,transparent_1px),linear-gradient(to_bottom,#ec4899_1px,transparent_1px)] bg-[size:20px_20px] animate-pulse"></div>
+          <div className="absolute inset-0 bg-gradient-to-t from-pink-500/20 via-transparent to-cyan-500/20"></div>
+          <Zap className="text-cyan-400 animate-bounce" size={32} />
+        </div>
+      );
+    case 'voidVortex':
+      return (
+        <div className="absolute inset-0 backface-hidden w-full h-full rounded-xl bg-black border-2 border-purple-900 flex items-center justify-center overflow-hidden shadow-xl hover:border-purple-500 transition-colors">
+          <div className="absolute inset-0 opacity-40 bg-[radial-gradient(circle_at_center,_var(--tw-gradient-stops))] from-purple-900 via-violet-950 to-black animate-spin [animation-duration:10s]"></div>
+          <div className="absolute w-32 h-32 rounded-full border border-purple-500/30 animate-ping [animation-duration:3s]"></div>
+          <Eye className="text-purple-400 animate-pulse" size={32} />
+        </div>
+      );
+    case 'goldenAether':
+      return (
+        <div className="absolute inset-0 backface-hidden w-full h-full rounded-xl bg-amber-950 border-2 border-yellow-600 flex items-center justify-center overflow-hidden shadow-xl hover:border-yellow-400 transition-colors">
+          <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_center,_var(--tw-gradient-stops))] from-yellow-400 via-amber-950 to-black"></div>
+          <div className="absolute inset-4 border border-yellow-600/30 rounded-lg flex items-center justify-center">
+            <div className="w-24 h-24 rotate-45 border-2 border-yellow-500/40 flex items-center justify-center">
+              <div className="w-16 h-16 -rotate-45 border border-yellow-400/50 flex items-center justify-center">
+                <Star className="text-yellow-400 animate-pulse" size={24} />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    case 'standard':
+    default:
+      return (
+        <div className="absolute inset-0 backface-hidden w-full h-full rounded-xl bg-slate-900 border-2 border-slate-700 flex items-center justify-center overflow-hidden shadow-xl hover:border-indigo-500 transition-colors">
+          <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_center,_var(--tw-gradient-stops))] from-indigo-500 via-slate-900 to-slate-900"></div>
+          <div className="grid grid-cols-6 grid-rows-6 gap-1 opacity-10 rotate-45 scale-150">
+             {[...Array(36)].map((_, i) => <div key={i} className="w-full h-full border border-indigo-500 group-hover:border-red-500 transition-colors duration-1000"></div>)}
+          </div>
+          <RotateCcw className="text-indigo-500 animate-pulse glitch-hover" size={32} />
+        </div>
+      );
+  }
+};
+
+const rarityBorders = {
+  common: 'border-white/10',
+  rare: 'border-slate-300 shadow-[0_0_10px_rgba(203,213,225,0.4)]',
+  'ultra-rare': 'border-yellow-500 shadow-[0_0_15px_rgba(234,179,8,0.5)]',
+  glitched: 'border-pink-500 shadow-[0_0_15px_rgba(236,72,153,0.5)] animate-pulse-glow',
+};
+
+export const Card = ({ data, isFlipped, onClick, size = 'md', showStats = true, clashing = false, deckBack = 'standard' }) => {
   const sizeClasses = {
     sm: 'w-24 h-40 text-xs',
     md: 'w-64 h-[28rem]',
@@ -19,6 +80,18 @@ export const Card = ({ data, isFlipped, onClick, size = 'md', showStats = true, 
   };
 
   const IconComponent = iconMap[data.icon] || <Sparkles size={64} />;
+  const activeDeckBack = data.deckBack || deckBack;
+
+  const frameStyles = {
+    standard: '',
+    neonGlow: `${glowColors[data.type] || glowColors.void} border-2 animate-pulse`,
+    goldFoil: 'border-yellow-500 border-4 shadow-[0_0_20px_rgba(234,179,8,0.5)]',
+    glitchMatrix: 'border-emerald-500 border-2 shadow-[0_0_20px_rgba(16,185,129,0.5)]',
+  };
+
+  const activeFrame = data.frame || 'standard';
+  const activeHat = data.hat || 'none';
+  const activeRarity = data.rarity || 'common';
 
   return (
     <div 
@@ -27,23 +100,45 @@ export const Card = ({ data, isFlipped, onClick, size = 'md', showStats = true, 
       style={{ perspective: '1000px', transformStyle: 'preserve-3d' }}
     >
       {/* CARD BACK */}
-      <div className="absolute inset-0 backface-hidden w-full h-full rounded-xl bg-slate-900 border-2 border-slate-700 flex items-center justify-center overflow-hidden shadow-xl hover:border-indigo-500 transition-colors">
-        <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_center,_var(--tw-gradient-stops))] from-indigo-500 via-slate-900 to-slate-900"></div>
-        <div className="grid grid-cols-6 grid-rows-6 gap-1 opacity-10 rotate-45 scale-150">
-           {[...Array(36)].map((_, i) => <div key={i} className="w-full h-full border border-indigo-500 group-hover:border-red-500 transition-colors duration-1000"></div>)}
-        </div>
-        <RotateCcw className="text-indigo-500 animate-pulse glitch-hover" size={32} />
-      </div>
+      {renderDeckBack(activeDeckBack)}
 
       {/* CARD FRONT */}
-      <div className={`absolute inset-0 backface-hidden rotate-y-180 w-full h-full rounded-xl bg-gradient-to-br ${getTypeColor(data.type)} border-2 backdrop-blur-md flex flex-col shadow-2xl overflow-hidden`}>
+      <div className={`absolute inset-0 backface-hidden rotate-y-180 w-full h-full rounded-xl bg-gradient-to-br ${getTypeColor(data.type)} border-2 ${rarityBorders[activeRarity]} ${frameStyles[activeFrame]} backdrop-blur-md flex flex-col shadow-2xl overflow-hidden`}>
         
+        {/* Decorative Effects */}
+        {activeFrame === 'glitchMatrix' && (
+          <div className="absolute inset-0 opacity-10 bg-[linear-gradient(to_bottom,rgba(16,185,129,0.15)_50%,transparent_50%)] bg-[size:100%_4px] pointer-events-none z-10"></div>
+        )}
+        {activeFrame === 'goldFoil' && (
+          <div className="absolute inset-0 opacity-10 bg-gradient-to-tr from-transparent via-white to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-1000 pointer-events-none z-10"></div>
+        )}
+
         {/* Tarot Inner Frame */}
         <div className="absolute inset-2 border border-white/10 rounded-lg pointer-events-none z-20"></div>
 
+        {/* Accessories / Hats */}
+        {activeHat === 'cyberCrown' && (
+          <div className="absolute -top-2 left-1/2 -translate-x-1/2 z-50 filter drop-shadow-[0_0_8px_rgba(234,179,8,0.8)] animate-bounce">
+            <Crown className="text-yellow-400 fill-yellow-400/20" size={24} />
+          </div>
+        )}
+        {activeHat === 'glitchHalo' && (
+          <div className="absolute top-[18%] left-1/2 -translate-x-1/2 z-20 w-16 h-4 rounded-[50%] border-2 border-cyan-400/80 shadow-[0_0_10px_rgba(34,211,238,0.8)] rotate-12 animate-pulse pointer-events-none"></div>
+        )}
+        {activeHat === 'retroVisor' && (
+          <div className="absolute top-[42%] left-0 right-0 h-6 bg-pink-500/30 border-y border-pink-500 shadow-[0_0_15px_rgba(236,72,153,0.8)] z-20 pointer-events-none flex items-center justify-center">
+            <span className="text-[8px] font-mono text-pink-300 tracking-[0.3em] animate-pulse">SYSTEM_ACTIVE</span>
+          </div>
+        )}
+
         {/* Top Header - Minimal */}
         <div className="p-4 flex justify-between items-start z-30">
-          <div className="text-[10px] font-mono tracking-widest text-white/50 uppercase">{data.type}</div>
+          <div className="flex flex-col">
+            <div className="text-[10px] font-mono tracking-widest text-white/50 uppercase">{data.type}</div>
+            {activeRarity !== 'common' && (
+              <div className="text-[8px] font-mono font-bold tracking-wider text-indigo-300 uppercase mt-0.5">{activeRarity}</div>
+            )}
+          </div>
           <div className="text-sm font-serif text-white/80 tracking-widest">{data.id}</div>
         </div>
 
@@ -72,6 +167,18 @@ export const Card = ({ data, isFlipped, onClick, size = 'md', showStats = true, 
               <p className="text-[11px] italic text-white/60 leading-relaxed font-serif line-clamp-3">
                 &ldquo;{data.desc}&rdquo;
               </p>
+            </div>
+          )}
+
+          {/* Active Ability display */}
+          {data.ability && data.ability !== 'none' && (
+            <div className="px-4 py-1 text-center bg-indigo-950/40 border-t border-white/5">
+              <span className="text-[8px] font-mono text-indigo-300 font-bold uppercase tracking-wider block">Ability: {data.ability.toUpperCase()}</span>
+              <span className="text-[8px] font-mono text-white/40 block">
+                {data.ability === 'overdrive' && '+10 ATK in Speed Blitz mode'}
+                {data.ability === 'ironWall' && '+20 DEF in Sudden Death mode'}
+                {data.ability === 'voidShield' && 'Ignores elemental advantages'}
+              </span>
             </div>
           )}
 

--- a/src/domain/battleEngine.js
+++ b/src/domain/battleEngine.js
@@ -73,15 +73,37 @@ export function resolveBattleWithEngine(p1, p2, modeId = 'standard') {
 
   const mode = arenaModes[modeId] || arenaModes.standard;
 
-  // 1. Resolve Base Score
+  // 1. Resolve Base Score with Ability modifiers
   const baseModifier = mode.modifiers.find(m => m.applyBase);
-  const p1Base = baseModifier ? baseModifier.applyBase(p1) : baseScoreComponent.calculate(p1);
-  const p2Base = baseModifier ? baseModifier.applyBase(p2) : baseScoreComponent.calculate(p2);
+  
+  // Apply Overdrive ability (+10 ATK in Speed Blitz)
+  const p1Stats = { ...p1.stats };
+  const p2Stats = { ...p2.stats };
+  if (p1.ability === 'overdrive' && modeId === 'speedBlitz') p1Stats.atk += 10;
+  if (p2.ability === 'overdrive' && modeId === 'speedBlitz') p2Stats.atk += 10;
 
-  // 2. Resolve Elemental Multiplier
+  const p1Modified = { ...p1, stats: p1Stats };
+  const p2Modified = { ...p2, stats: p2Stats };
+
+  let p1Base = baseModifier ? baseModifier.applyBase(p1Modified) : baseScoreComponent.calculate(p1Modified);
+  let p2Base = baseModifier ? baseModifier.applyBase(p2Modified) : baseScoreComponent.calculate(p2Modified);
+
+  // Apply Iron Wall ability (+20 base score in Sudden Death)
+  if (p1.ability === 'ironWall' && modeId === 'suddenDeath') p1Base += 20;
+  if (p2.ability === 'ironWall' && modeId === 'suddenDeath') p2Base += 20;
+
+  // 2. Resolve Elemental Multiplier with Ability modifiers
   const elementalModifier = mode.modifiers.find(m => m.applyElemental);
-  const p1Adv = elementalModifier ? elementalModifier.applyElemental(p1, p2) : elementalComponent.calculate(p1, p2);
-  const p2Adv = elementalModifier ? elementalModifier.applyElemental(p2, p1) : elementalComponent.calculate(p2, p1);
+  let p1Adv = elementalModifier ? elementalModifier.applyElemental(p1, p2) : elementalComponent.calculate(p1, p2);
+  let p2Adv = elementalModifier ? elementalModifier.applyElemental(p2, p1) : elementalComponent.calculate(p2, p1);
+
+  // Apply Void Shield ability (ignores elemental advantages)
+  if (p2.ability === 'voidShield') {
+    p1Adv = 1.0;
+  }
+  if (p1.ability === 'voidShield') {
+    p2Adv = 1.0;
+  }
 
   // 3. Aggregate Scores
   const p1Score = p1Base * p1Adv;

--- a/src/domain/battleEngine.test.js
+++ b/src/domain/battleEngine.test.js
@@ -80,5 +80,46 @@ describe('battleEngine', () => {
       expect(result.p2Score).toBe(0);
       expect(result.logLine).toBe('> SYSTEMS IN HARMONY. NO CLASH POSSIBLE.');
     });
+
+    describe('TCG Active Abilities', () => {
+      it('processes overdrive ability correctly in speedBlitz mode', () => {
+        const p1Overdrive = { ...p1, ability: 'overdrive' };
+        // speedBlitz: (ATK + SPD * 2) * Elemental Advantage
+        // p1 standard speedBlitz: (50 + 20 * 2) * 1.5 = 135
+        // p1 overdrive speedBlitz: ((50 + 10) + 20 * 2) * 1.5 = 150
+        const result = resolveBattleWithEngine(p1Overdrive, p2, 'speedBlitz');
+        expect(result.p1Score).toBe(150);
+
+        // standard mode: overdrive should not apply
+        const standardResult = resolveBattleWithEngine(p1Overdrive, p2, 'standard');
+        expect(standardResult.p1Score).toBe(105);
+      });
+
+      it('processes ironWall ability correctly in suddenDeath mode', () => {
+        const p1IronWall = { ...p1, ability: 'ironWall' };
+        // suddenDeath: (ATK * 3) with no elemental advantages
+        // p1 standard suddenDeath: (50 * 3) = 150
+        // p1 ironWall suddenDeath: (50 * 3) + 20 = 170
+        const result = resolveBattleWithEngine(p1IronWall, p2, 'suddenDeath');
+        expect(result.p1Score).toBe(170);
+
+        // standard mode: ironWall should not apply
+        const standardResult = resolveBattleWithEngine(p1IronWall, p2, 'standard');
+        expect(standardResult.p1Score).toBe(105);
+      });
+
+      it('processes voidShield ability correctly by ignoring elemental advantages', () => {
+        const p2VoidShield = { ...p2, ability: 'voidShield' };
+        // Fire (p1) usually has 1.5x advantage over Wind (p2)
+        // With voidShield on p2, p1's advantage is forced to 1.0x
+        // p1 score: (50 + 20) * 1.0 = 70
+        // p2 score: (40 + 30) * 1.0 = 70
+        const result = resolveBattleWithEngine(p1, p2VoidShield, 'standard');
+        expect(result.p1Advantage).toBe(1.0);
+        expect(result.p1Score).toBe(70);
+        expect(result.p2Score).toBe(70);
+        expect(result.winner).toBeNull(); // Draw due to equal scores
+      });
+    });
   });
 });

--- a/src/domain/deckState.js
+++ b/src/domain/deckState.js
@@ -23,12 +23,22 @@ export function forgeCard(deck, forgeData) {
   return { ...forgeData, id: newId };
 }
 
-export function drawSpread(deck, rng = Math.random) {
+export function drawSpread(deck, countOrRng = 3, rng = Math.random) {
   if (!Array.isArray(deck) || deck.length === 0) return [];
+
+  let count = 3;
+  let activeRng = rng;
+
+  if (typeof countOrRng === 'function') {
+    activeRng = countOrRng;
+  } else if (typeof countOrRng === 'number') {
+    count = countOrRng;
+  }
+
   const shuffled = [...deck];
   for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
+    const j = Math.floor(activeRng() * (i + 1));
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
-  return shuffled.slice(0, 3);
+  return shuffled.slice(0, count);
 }


### PR DESCRIPTION
## Summary
This PR introduces custom card cosmetics, dynamic deck backs, dynamic spread layouts for the Oracle view, and new TCG mechanics integrated into the decoupled battle engine:
- **Custom Card Cosmetics**: Added Card Frames (Standard, Neon Glow, Gold Foil, Glitch Matrix) and Accessories/Hats (None, Cyber Crown, Glitch Halo, Retro Visor) to `Card.jsx` and the Forge view.
- **Custom Deck Backs**: Added Deck Backs (Standard, Cyberpunk Grid, Void Vortex, Golden Aether) selectable in the Settings modal.
- **Dynamic Spread Layouts**: Expanded the Oracle view to support Past/Present/Future (3 cards), Celtic Cross (5 cards), and The Clash (3 cards) layouts with beautiful responsive grids.
- **TCG Active Abilities**: Introduced Card Rarities (Common, Rare, Ultra-Rare, Glitched) and Active Abilities (Overdrive, Iron Wall, Void Shield) processed dynamically by the decoupled battle engine.

## Test Plan
- Ran `npm run test` to verify all 41 unit and integration tests pass successfully (including new tests for active abilities, settings, forge customization, and oracle layouts).
- Verified zero ESLint errors or warnings via `npm run lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Active Deck Back" selector in Settings for card customization.
  * Expanded Oracle with three spread layout options.
  * Extended Forge with controls for card frame, accessory, rarity, and active ability.
  * Displayed active abilities on cards.
  * Implemented ability-specific battle mechanics.

* **Tests**
  * Added UI and battle engine tests covering new features and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->